### PR TITLE
Provide web state via init data instead of native function

### DIFF
--- a/Source/binary/js/main.js
+++ b/Source/binary/js/main.js
@@ -6,7 +6,6 @@ class App {
     this.getModels = getNativeFunction("getModels");
     this.getRegionSequences = getNativeFunction("getRegionSequences");
     this.getTranscriptionStatus = getNativeFunction("getTranscriptionStatus");
-    this.getWebState = getNativeFunction("getWebState");
     this.getWhisperLanguages = getNativeFunction("getWhisperLanguages");
     this.play = getNativeFunction("play");
     this.stop = getNativeFunction("stop");
@@ -39,12 +38,12 @@ class App {
   }
 
   loadState() {
-    return this.getWebState().then((state) => {
-      if (state) {
-        this.state = JSON.parse(state);
-      }
-      return this.state;
-    });
+    try {
+      this.state = JSON.parse(window.__JUCE__.initialisationData.webState);
+    } catch (e) {
+      console.warn('Failed to parse web state:', e);
+    }
+    return Promise.resolve();
   }
 
   saveState() {

--- a/Source/ui/NativeFunctions.h
+++ b/Source/ui/NativeFunctions.h
@@ -42,7 +42,6 @@ public:
             .withNativeFunction ("getModels", bindFn (&NativeFunctions::getModels))
             .withNativeFunction ("getRegionSequences", bindFn (&NativeFunctions::getRegionSequences))
             .withNativeFunction ("getTranscriptionStatus", bindFn (&NativeFunctions::getTranscriptionStatus))
-            .withNativeFunction ("getWebState", bindFn (&NativeFunctions::getWebState))
             .withNativeFunction ("getWhisperLanguages", bindFn (&NativeFunctions::getWhisperLanguages))
             .withNativeFunction ("play", bindFn (&NativeFunctions::play))
             .withNativeFunction ("stop", bindFn (&NativeFunctions::stop))
@@ -189,11 +188,6 @@ public:
                 break;
         }
         complete (juce::var (status));
-    }
-
-    void getWebState (const juce::var&, std::function<void (const juce::var&)> complete)
-    {
-        complete (audioProcessor.state.getProperty ("webState"));
     }
 
     void getWhisperLanguages (const juce::var&, std::function<void (const juce::var&)> complete)

--- a/Source/ui/ReaSpeechLiteAudioProcessorEditor.h
+++ b/Source/ui/ReaSpeechLiteAudioProcessorEditor.h
@@ -25,6 +25,7 @@ public:
                     .withWinWebView2Options (juce::WebBrowserComponent::Options::WinWebView2{}
                         .withUserDataFolder (juce::File::getSpecialLocation (juce::File::SpecialLocationType::tempDirectory)))
                     .withResourceProvider ([] (const auto& url) { return Resources::get (url); })
+                    .withInitialisationData ("webState", p.state.getProperty ("webState", juce::var()).toString())
                     .withNativeIntegrationEnabled()
                     .withOptionsFrom (*nativeFunctions)
             );


### PR DESCRIPTION
Turns out, passing a large amount of data through a NativeFunction is very slow. Using init data instead resulted in a huge improvement in plugin startup time with a large transcript, from beach-balling for 45 seconds to nearly instantaneous.