### PR TITLE
Simplify resource definition

### DIFF
--- a/Source/ui/Resources.h
+++ b/Source/ui/Resources.h
@@ -6,74 +6,45 @@ struct Resources
 {
     static std::optional<juce::WebBrowserComponent::Resource> get (const juce::String& url)
     {
+        static const std::unordered_map<juce::String, ResourceData> resourceMap =
+        {
+            { "index.html", { BinaryData::index_html, BinaryData::index_htmlSize, "text/html" } },
+            { "css/bootstrap.min.css", { BinaryData::bootstrap_min_css, BinaryData::bootstrap_min_cssSize, "text/css" } },
+            { "css/bootstrap.min.css.map", { BinaryData::bootstrap_min_css_map, BinaryData::bootstrap_min_css_mapSize, "application/json" } },
+            { "img/tech-audio-logo.png", { BinaryData::techaudiologo_png, BinaryData::techaudiologo_pngSize, "image/png" } },
+            { "js/bootstrap.bundle.min.js", { BinaryData::bootstrap_bundle_min_js, BinaryData::bootstrap_bundle_min_jsSize, "application/javascript" } },
+            { "js/bootstrap.bundle.min.js.map", { BinaryData::bootstrap_bundle_min_js_map, BinaryData::bootstrap_bundle_min_js_mapSize, "application/json" } },
+            { "js/main.js", { BinaryData::main_js, BinaryData::main_jsSize, "application/javascript" } }
+        };
+
         const auto urlToRetrieve = url == "/" ? juce::String { "index.html" }
                                               : url.fromFirstOccurrenceOf ("/", false, false);
 
-        if (urlToRetrieve == "index.html")
-        {
-            return juce::WebBrowserComponent::Resource {
-                getBinaryData (BinaryData::index_html, BinaryData::index_htmlSize),
-                "text/html"
-            };
-        }
-
-        if (urlToRetrieve == "css/bootstrap.min.css")
-        {
-            return juce::WebBrowserComponent::Resource {
-                getBinaryData (BinaryData::bootstrap_min_css, BinaryData::bootstrap_min_cssSize),
-                "text/css"
-            };
-        }
-
-        if (urlToRetrieve == "css/bootstrap.min.css.map")
-        {
-            return juce::WebBrowserComponent::Resource {
-                getBinaryData (BinaryData::bootstrap_min_css_map, BinaryData::bootstrap_min_css_mapSize),
-                "application/json"
-            };
-        }
-
-        if (urlToRetrieve == "img/tech-audio-logo.png")
-        {
-            return juce::WebBrowserComponent::Resource {
-                getBinaryData (BinaryData::techaudiologo_png, BinaryData::techaudiologo_pngSize),
-                "image/png"
-            };
-        }
-
-        if (urlToRetrieve == "js/bootstrap.bundle.min.js")
-        {
-            return juce::WebBrowserComponent::Resource {
-                getBinaryData (BinaryData::bootstrap_bundle_min_js, BinaryData::bootstrap_bundle_min_jsSize),
-                "application/javascript"
-            };
-        }
-
-        if (urlToRetrieve == "js/bootstrap.bundle.min.js.map")
-        {
-            return juce::WebBrowserComponent::Resource {
-                getBinaryData (BinaryData::bootstrap_bundle_min_js_map, BinaryData::bootstrap_bundle_min_js_mapSize),
-                "application/json"
-            };
-        }
-
-        if (urlToRetrieve == "js/main.js")
-        {
-            return juce::WebBrowserComponent::Resource {
-                getBinaryData (BinaryData::main_js, BinaryData::main_jsSize),
-                "application/javascript"
-            };
-        }
+        const auto it = resourceMap.find (urlToRetrieve);
+        if (it != resourceMap.end())
+            return it->second.getResource();
 
         return {};
     }
 
 private:
-    static std::vector<std::byte> getBinaryData (const char* data, size_t size)
+    struct ResourceData
     {
-        return std::vector<std::byte>(
-            reinterpret_cast<const std::byte*>(data),
-            reinterpret_cast<const std::byte*>(data + size)
-        );
-    }
+        const char* data;
+        size_t size;
+        const char* mimeType;
+
+        std::vector<std::byte> getBinaryData() const
+        {
+            return std::vector<std::byte> (
+                reinterpret_cast<const std::byte*> (data),
+                reinterpret_cast<const std::byte*> (data + size)
+            );
+        }
+
+        juce::WebBrowserComponent::Resource getResource() const
+        {
+            return { getBinaryData(), mimeType };
+        }
+    };
 };


### PR DESCRIPTION
Introduce a map and struct to reduce the amount of boilerplate in defining web resources.