### PR TITLE
Add CMake command for Linux/CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# reaspeech-lite
+# ReaSpeechLite
 
 Speech-to-text transcription VST3/ARA plugin
 
@@ -8,12 +8,15 @@ Speech-to-text transcription VST3/ARA plugin
 
 ## CMake initialization
 
-    mkdir build
     cmake -B build -DCMAKE_BUILD_TYPE=Debug
 
 For Windows/CUDA, use:
 
     cmake -B build -DCMAKE_BUILD_TYPE=Debug -DGGML_CUDA=1
+
+For Linux/CUDA, use:
+
+    cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DGGML_CUDA=1
 
 ## Building
 


### PR DESCRIPTION
I was able to get GPU acceleration working in Linux by using clang instead of gcc/g++. The following packages were required:

- clang
- cmake
- cuda-toolkit
- libstdc++-14-dev

And the rest of the dependencies documented here: https://github.com/juce-framework/JUCE/blob/master/docs/Linux%20Dependencies.md