### PR TITLE
Remove use of JuceHeader.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,8 +149,6 @@ else()
     )
 endif()
 
-juce_generate_juce_header(${PROJECT_NAME})
-
 # This lets us use our code in both the JUCE targets and our Test target
 # Without running into ODR violations
 add_library(SharedCode INTERFACE)
@@ -179,8 +177,6 @@ include(XcodePrettify)
 # This is where you can set preprocessor definitions for JUCE and your plugin
 target_compile_definitions(SharedCode
     INTERFACE
-
-    DONT_SET_USING_JUCE_NAMESPACE=1
 
     # JUCE_WEB_BROWSER and JUCE_USE_CURL off by default
     JUCE_WEB_BROWSER=1  # If you set this to 1, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call

--- a/source/Config.h
+++ b/source/Config.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <string>
+#include <vector>
+
+#include <juce_core/juce_core.h>
 
 struct Config
 {

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -1,4 +1,5 @@
-#include <JuceHeader.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
 
 #include "ara/ReaSpeechLiteDocumentController.h"
 #include "plugin/ReaSpeechLiteAudioProcessor.h"

--- a/source/ara/ReaSpeechLiteDocumentController.h
+++ b/source/ara/ReaSpeechLiteDocumentController.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
 
 #include "../types/ProcessingLockInterface.h"
 #include "ReaSpeechLitePlaybackRenderer.h"

--- a/source/ara/ReaSpeechLitePlaybackRenderer.h
+++ b/source/ara/ReaSpeechLitePlaybackRenderer.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <map>
+#include <memory>
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
 
 #include "../types/ProcessingLockInterface.h"
 #include "../utils/ResamplingDriver.h"

--- a/source/asr/ASREngine.h
+++ b/source/asr/ASREngine.h
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <juce_core/juce_core.h>
 #include <whisper.h>
 
 #include "../utils/SafeUTF8.h"

--- a/source/asr/ASROptions.h
+++ b/source/asr/ASROptions.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_core/juce_core.h>
 
 struct ASROptions
 {

--- a/source/asr/ASRSegment.h
+++ b/source/asr/ASRSegment.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_core/juce_core.h>
 
 struct ASRWord
 {

--- a/source/asr/ASRThreadPoolJob.h
+++ b/source/asr/ASRThreadPoolJob.h
@@ -1,6 +1,12 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
 #include <whisper.h>
 
 #include "../utils/ResamplingExporter.h"

--- a/source/asr/WhisperLanguages.h
+++ b/source/asr/WhisperLanguages.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_core/juce_core.h>
 #include <whisper.h>
 
 class WhisperLanguages

--- a/source/plugin/ReaSpeechLiteAudioProcessor.h
+++ b/source/plugin/ReaSpeechLiteAudioProcessor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_audio_processors/juce_audio_processors.h>
 
 #include "../ui/ReaSpeechLiteAudioProcessorEditor.h"
 #include "ReaSpeechLiteAudioProcessorImpl.h"

--- a/source/plugin/ReaSpeechLiteAudioProcessorImpl.h
+++ b/source/plugin/ReaSpeechLiteAudioProcessorImpl.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
 
 #include "../reaper/ReaperProxy.h"
 #include "../reaper/VST3Extensions.h"

--- a/source/reaper/IReaperHostApplication.h
+++ b/source/reaper/IReaperHostApplication.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_core/juce_core.h>
 
 JUCE_BEGIN_IGNORE_WARNINGS_GCC_LIKE ("-Wshadow-field-in-constructor",
                                      "-Wnon-virtual-dtor")

--- a/source/reaper/ReaperProxy.h
+++ b/source/reaper/ReaperProxy.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <JuceHeader.h>
-#include <stdexcept>
+#include <exception>
+#include <juce_core/juce_core.h>
 
 #include "IReaperHostApplication.h"
 

--- a/source/reaper/VST3Extensions.h
+++ b/source/reaper/VST3Extensions.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_audio_processors/juce_audio_processors.h>
 
 #include "IReaperHostApplication.h"
 #include "ReaperProxy.h"

--- a/source/types/MarkerType.h
+++ b/source/types/MarkerType.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <optional>
+#include <string>
+
 struct MarkerType
 {
     enum Enum

--- a/source/types/ProcessingLockInterface.h
+++ b/source/types/ProcessingLockInterface.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_core/juce_core.h>
 
 struct ProcessingLockInterface
 {

--- a/source/ui/NativeFunctions.h
+++ b/source/ui/NativeFunctions.h
@@ -1,7 +1,12 @@
 #pragma once
 
-#include <JuceHeader.h>
 #include <atomic>
+#include <functional>
+#include <memory>
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "../Config.h"
 #include "../asr/ASREngine.h"

--- a/source/ui/ReaSpeechLiteAudioProcessorEditor.h
+++ b/source/ui/ReaSpeechLiteAudioProcessorEditor.h
@@ -1,6 +1,13 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <memory>
+
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
+#include <juce_data_structures/juce_data_structures.h>
+#include <juce_graphics/juce_graphics.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
 
 #include "../plugin/ReaSpeechLiteAudioProcessorImpl.h"
 #include "NativeFunctions.h"

--- a/source/ui/Resources.h
+++ b/source/ui/Resources.h
@@ -1,6 +1,13 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include <juce_core/juce_core.h>
+#include <juce_gui_extra/juce_gui_extra.h>
+
+#include "BinaryData.h"
 
 struct Resources
 {

--- a/source/utils/ResamplingDriver.h
+++ b/source/utils/ResamplingDriver.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <memory>
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
 
 class ResamplingDriver
 {

--- a/source/utils/ResamplingExporter.h
+++ b/source/utils/ResamplingExporter.h
@@ -1,6 +1,13 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_audio_processors/juce_audio_processors.h>
+#include <juce_core/juce_core.h>
 
 struct ResamplingExporter
 {

--- a/source/utils/SafeUTF8.h
+++ b/source/utils/SafeUTF8.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <string>
+#include <juce_core/juce_core.h>
 
 struct SafeUTF8
 {

--- a/source/utils/SharedTimeSliceThread.h
+++ b/source/utils/SharedTimeSliceThread.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JuceHeader.h>
+#include <juce_core/juce_core.h>
 
 class SharedTimeSliceThread final : public juce::TimeSliceThread
 {


### PR DESCRIPTION
This removes the generation and usage of JuceHeader.h, which is a convenience header that is generated by Projucer. Pamplejuce is designed assuming this header is not used, so various targets like Tests do not work properly.

Instead of using this one header, it's necessary to import the specific JUCE libraries that are in use. I made a best effort to import the headers that are actually used by each file.