### PR TITLE
Fix ARA config for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ juce_add_plugin("${PROJECT_NAME}"
     COMPANY_NAME "${COMPANY_NAME}"
     COMPANY_WEBSITE https://techaud.io
     BUNDLE_ID "${BUNDLE_ID}"
+    ARA_FACTORY_ID "${BUNDLE_ID}"
 
     # On MacOS, plugin is copied to /Users/yourname/Library/Audio/Plug-Ins/
     # COPY_PLUGIN_AFTER_BUILD TRUE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(PRODUCT_NAME "ReaSpeechLite")
 set(COMPANY_NAME "TechAudio")
 
 # Change me! Used for the MacOS bundle identifier (and signing)
-set(BUNDLE_ID "io.techaud.reaspeech-lite")
+set(BUNDLE_ID "com.TechAudio.ReaSpeechLite")
 
 # Change me! Set the plugin formats you want built
 # Valid choices: AAX Unity VST VST3 AU AUv3 Standalone
@@ -95,7 +95,6 @@ juce_add_plugin("${PROJECT_NAME}"
     COMPANY_NAME "${COMPANY_NAME}"
     COMPANY_WEBSITE https://techaud.io
     BUNDLE_ID "${BUNDLE_ID}"
-    ARA_FACTORY_ID "${BUNDLE_ID}"
 
     # On MacOS, plugin is copied to /Users/yourname/Library/Audio/Plug-Ins/
     # COPY_PLUGIN_AFTER_BUILD TRUE


### PR DESCRIPTION
When launching the plugin on Linux, since merging the Pamplejuce CMake configuration, it has been rendering as a blank window for me. If I right-click on the window, I can see that it's a valid WebKit instance, but it is pointed to "about:blank", and it doesn't seem to be able to receive any messages like `getUrl`, so the interface never renders.

I tried reverting various parts of CMakeLists.txt, and nothing seemed to have any effect until I tried replacing the entire call to `juce_add_plugin` with what we previously had. The issue went away as soon as I did that.

I then tried going back to the current main code, but commented out the line that said `BUNDLE_ID "${BUNDLE_ID}"`, and that also resolved the problem. Curious, I noticed that in build/ReaSpeechLite_artefacts/JuceLibraryCode/Info.txt, the value for BUNDLE_ID defaulted to "com.TechAudio.ReaSpeechLite", instead of the custom value of "io.techaud.reaspeech-lite". This gets set in _juce_set_fallback_properties, defined in JUCEUtils.cmake.

Searching documentation for BUNDLE_ID, I found this in JUCE/docs/CMAKE api.md:

```
ARA_FACTORY_ID

A globally unique and versioned identifier string. If not provided a sensible default will be generated using the BUNDLE_ID and VERSION values. The version must be updated if e.g. the plugin's (compatible) document archive ID(s) or its analysis or playback transformation capabilities change.
```

So, it seems like when BUNDLE_ID is not specified, the default for BUNDLE_ID and ARA_FACTORY_ID match up, but if one is set and not the other, then they are no longer equivalent. A related symptom seems to be that when loading existing projects with the plugin saved to the project, displays the message about ARA being unavailable. So, it seems like this mismatch is causing ARA to not initialize completely, and that is preventing the UI from loading.

I don't completely understand what is going on here, but this seems to be the fix.