### PR TITLE
Add ability to create notes in Reaper

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -56,6 +56,7 @@
           <ul class="dropdown-menu">
             <li><a id="create-markers" class="dropdown-item" href="javascript:">Markers</a></li>
             <li><a id="create-regions" class="dropdown-item" href="javascript:">Regions</a></li>
+            <li><a id="create-notes" class="dropdown-item" href="javascript:">Notes</a></li>
           </ul>
         </div>
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -31,6 +31,7 @@ class App {
     document.getElementById('process-button').onclick = () => { this.handleProcess(); };
     document.getElementById('create-markers').onclick = () => { this.handleCreateMarkers('markers'); };
     document.getElementById('create-regions').onclick = () => { this.handleCreateMarkers('regions'); };
+    document.getElementById('create-notes').onclick = () => { this.handleCreateMarkers('notes'); };
 
     setInterval(() => {
       this.update();

--- a/source/reaper/ReaperProxy.h
+++ b/source/reaper/ReaperProxy.h
@@ -24,11 +24,26 @@ struct ReaperProxy
             return;
 
         hasAddProjectMarker2 = reaperHost->getReaperApi("AddProjectMarker2");
+        hasGetCursorPositionEx = reaperHost->getReaperApi("GetCursorPositionEx");
+        hasGetItemStateChunk = reaperHost->getReaperApi("GetItemStateChunk");
+        hasGetSelectedMediaItem = reaperHost->getReaperApi("GetSelectedMediaItem");
+        hasGetSetMediaTrackInfo_String = reaperHost->getReaperApi("GetSetMediaTrackInfo_String");
+        hasGetTrack = reaperHost->getReaperApi("GetTrack");
+        hasInsertTrackInProject = reaperHost->getReaperApi("InsertTrackInProject");
+        hasMain_OnCommandEx = reaperHost->getReaperApi("Main_OnCommandEx");
         hasPreventUIRefresh = reaperHost->getReaperApi("PreventUIRefresh");
+        hasSelectAllMediaItems = reaperHost->getReaperApi("SelectAllMediaItems");
+        hasSetEditCurPos2 = reaperHost->getReaperApi("SetEditCurPos2");
+        hasSetItemStateChunk = reaperHost->getReaperApi("SetItemStateChunk");
+        hasSetMediaItemLength = reaperHost->getReaperApi("SetMediaItemLength");
+        hasSetMediaItemPosition = reaperHost->getReaperApi("SetMediaItemPosition");
+        hasSetOnlyTrackSelected = reaperHost->getReaperApi("SetOnlyTrackSelected");
         hasUndo_BeginBlock2 = reaperHost->getReaperApi("Undo_BeginBlock2");
         hasUndo_EndBlock2 = reaperHost->getReaperApi("Undo_EndBlock2");
     }
 
+    class MediaItem;
+    class MediaTrack;
     class ReaProject;
 
     static constexpr ReaProject* activeProject = nullptr;
@@ -47,10 +62,88 @@ struct ReaperProxy
         REAPER_CALL(AddProjectMarker2, int (*) (ReaProject*, bool, double, double, const char*, int, int), proj, isrgn, pos, rgnend, name, wantidx, color)
     }
 
+    void* hasGetCursorPositionEx = nullptr;
+    double GetCursorPositionEx (ReaProject* proj)
+    {
+        REAPER_CALL(GetCursorPositionEx, double (*) (ReaProject*), proj)
+    }
+
+    void* hasGetItemStateChunk = nullptr;
+    bool GetItemStateChunk (MediaItem* item, char* strNeedBig, int strNeedBig_sz, bool isundoOptional)
+    {
+        REAPER_CALL(GetItemStateChunk, bool (*) (MediaItem*, char*, int, bool), item, strNeedBig, strNeedBig_sz, isundoOptional)
+    }
+
+    void* hasGetSelectedMediaItem = nullptr;
+    MediaItem* GetSelectedMediaItem (ReaProject* proj, int selitem)
+    {
+        REAPER_CALL(GetSelectedMediaItem, MediaItem* (*) (ReaProject*, int), proj, selitem)
+    }
+
+    void* hasGetSetMediaTrackInfo_String = nullptr;
+    bool GetSetMediaTrackInfo_String (MediaTrack* tr, const char* parmname, char* stringNeedBig, bool setNewValue)
+    {
+        REAPER_CALL(GetSetMediaTrackInfo_String, bool (*) (MediaTrack*, const char*, char*, bool), tr, parmname, stringNeedBig, setNewValue)
+    }
+
+    void* hasGetTrack = nullptr;
+    MediaTrack* GetTrack (ReaProject* proj, int trackidx)
+    {
+        REAPER_CALL(GetTrack, MediaTrack* (*) (ReaProject*, int), proj, trackidx)
+    }
+
+    void* hasInsertTrackInProject = nullptr;
+    MediaTrack* InsertTrackInProject (ReaProject* proj, int idx, int flags)
+    {
+        REAPER_CALL(InsertTrackInProject, MediaTrack* (*) (ReaProject*, int, int), proj, idx, flags)
+    }
+
+    void* hasMain_OnCommandEx = nullptr;
+    void Main_OnCommandEx (int command, int flag, ReaProject* proj)
+    {
+        REAPER_CALL(Main_OnCommandEx, void (*) (int, int, ReaProject*), command, flag, proj)
+    }
+
     void* hasPreventUIRefresh = nullptr;
     void PreventUIRefresh (int state)
     {
         REAPER_CALL(PreventUIRefresh, void (*) (int), state)
+    }
+
+    void* hasSelectAllMediaItems = nullptr;
+    void SelectAllMediaItems (ReaProject* proj, bool selected)
+    {
+        REAPER_CALL(SelectAllMediaItems, void (*) (ReaProject*, bool), proj, selected)
+    }
+
+    void* hasSetEditCurPos2 = nullptr;
+    void SetEditCurPos2 (ReaProject* proj, double time, bool moveview, bool seekplay)
+    {
+        REAPER_CALL(SetEditCurPos2, void (*) (ReaProject*, double, bool, bool), proj, time, moveview, seekplay)
+    }
+
+    void* hasSetItemStateChunk = nullptr;
+    bool SetItemStateChunk (MediaItem* item, const char* str, bool isundoOptional)
+    {
+        REAPER_CALL(SetItemStateChunk, bool (*) (MediaItem*, const char*, bool), item, str, isundoOptional)
+    }
+
+    void* hasSetMediaItemLength = nullptr;
+    void SetMediaItemLength (MediaItem* item, double length, bool refreshUI)
+    {
+        REAPER_CALL(SetMediaItemLength, void (*) (MediaItem*, double, bool), item, length, refreshUI)
+    }
+
+    void* hasSetMediaItemPosition = nullptr;
+    void SetMediaItemPosition (MediaItem* item, double position, bool refreshUI)
+    {
+        REAPER_CALL(SetMediaItemPosition, void (*) (MediaItem*, double, bool), item, position, refreshUI)
+    }
+
+    void* hasSetOnlyTrackSelected = nullptr;
+    void SetOnlyTrackSelected (MediaTrack* track)
+    {
+        REAPER_CALL(SetOnlyTrackSelected, void (*) (MediaTrack*), track)
     }
 
     void* hasUndo_BeginBlock2 = nullptr;

--- a/source/types/MarkerType.h
+++ b/source/types/MarkerType.h
@@ -8,26 +8,29 @@ struct MarkerType
     enum Enum
     {
         markers,
-        regions
+        regions,
+        notes,
+        count // Used for array size
+    };
+
+    static constexpr std::array<std::string_view, count> strings = {
+        "markers",
+        "regions",
+        "notes"
     };
 
     static std::optional<Enum> fromString (const std::string& str)
     {
-        if (str == "markers")
-            return markers;
-        else if (str == "regions")
-            return regions;
-        else
-            return std::nullopt;
+        for (size_t i = 0; i < strings.size(); ++i)
+            if (str == strings[i])
+                return static_cast<Enum> (i);
+        return std::nullopt;
     }
 
     static std::string toString (Enum type)
     {
-        switch (type)
-        {
-            case markers: return "markers";
-            case regions: return "regions";
-        }
+        if (type >= 0 && type < count)
+            return std::string (strings[type]);
         return "";
     }
 };

--- a/source/types/MarkerType.h
+++ b/source/types/MarkerType.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <array>
 #include <optional>
 #include <string>
+#include <string_view>
 
 struct MarkerType
 {

--- a/source/ui/NativeFunctions.h
+++ b/source/ui/NativeFunctions.h
@@ -408,6 +408,11 @@ private:
         rpr.GetItemStateChunk (item, buffer, sizeof (buffer), false);
         const auto chunk = juce::String (buffer);
 
+        // This function is currently only used with new items, and the chunk size
+        // in that case is currently around 200 bytes. If this changes, the buffer
+        // size may need to be increased. The current size is a bit arbitrary.
+        jassert (static_cast<size_t> (chunk.length()) < sizeof (buffer));
+
         juce::String notesChunk;
         notesChunk << "<NOTES\n|" << text.trim() << "\n>\n";
         const juce::String flagsChunk { stretch ? "IMGRESOURCEFLAGS 11\n" : "" };

--- a/source/ui/NativeFunctions.h
+++ b/source/ui/NativeFunctions.h
@@ -411,7 +411,9 @@ private:
         // This function is currently only used with new items, and the chunk size
         // in that case is currently around 200 bytes. If this changes, the buffer
         // size may need to be increased. The current size is a bit arbitrary.
-        jassert (static_cast<size_t> (chunk.length()) < sizeof (buffer));
+        auto chunkSize = static_cast<size_t> (chunk.length());
+        auto bufferSize = sizeof (buffer);
+        jassert (chunkSize < bufferSize - 1);
 
         juce::String notesChunk;
         notesChunk << "<NOTES\n|" << text.trim() << "\n>\n";


### PR DESCRIPTION
This adds the ability to add "notes tracks" (matching the behavior of ReaSpeech), which are tracks containing text notes as an alternative to markers or regions.

Did some minor refactoring to make it easier to add MarkerTypes.

The stretching feature from ReaSpeech is implemented but currently disabled. Likewise, with the ability to change the track name.