### PR TITLE
Multiple regions fix

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -196,48 +196,70 @@ class App {
     });
 
     this.getRegionSequences().then((regionSequences) => {
+      // First, collect all playback regions by audio source ID
+      const playbackRegionsByAudioSource = {};
+
       for (let i = 0; i < regionSequences.length; i++) {
         const rs = regionSequences[i];
 
         for (let j = 0; j < rs.playbackRegions.length; j++) {
           const pr = rs.playbackRegions[j];
+          const audioSourceID = pr.audioSourcePersistentID;
+
+          if (!playbackRegionsByAudioSource[audioSourceID]) {
+            playbackRegionsByAudioSource[audioSourceID] = [];
+          }
+          playbackRegionsByAudioSource[audioSourceID].push(pr);
+        }
+      }
+
+      // Now process each segment
+      const segments = document.querySelectorAll('.segment');
+      segments.forEach((segment) => {
+        const source = segment.querySelector('.segment-source');
+        const sourceID = source.dataset.persistentId;
+        const playbackRegions = playbackRegionsByAudioSource[sourceID] || [];
+
+        const startElement = segment.querySelector('.segment-start');
+        const endElement = segment.querySelector('.segment-end');
+        const textElement = segment.querySelector('.segment-text');
+
+        // Default: no playable region found
+        let isPlayable = false;
+
+        // Try to find a playback region where this segment is playable
+        for (const pr of playbackRegions) {
+          const segmentStart = parseFloat(startElement.dataset.segmentTime);
+          const segmentEnd = parseFloat(endElement.dataset.segmentTime);
 
           const playbackStart = pr.playbackStart;
           const playbackEnd = pr.playbackEnd;
           const modificationStart = pr.modificationStart;
-          const audioSourcePersistentID = pr.audioSourcePersistentID;
 
-          const segments = document.querySelectorAll('.segment');
-          segments.forEach((segment) => {
-            const source = segment.querySelector('.segment-source');
+          let start = playbackStart + segmentStart - modificationStart;
+          let end = playbackStart + segmentEnd - modificationStart;
 
-            if (source.dataset.persistentId === audioSourcePersistentID) {
-              const startElement = segment.querySelector('.segment-start');
-              const endElement = segment.querySelector('.segment-end');
-              const textElement = segment.querySelector('.segment-text');
-              const segmentStart = parseFloat(startElement.dataset.segmentTime);
-              const segmentEnd = parseFloat(endElement.dataset.segmentTime);
-
-              let start = playbackStart + segmentStart - modificationStart;
-              let end = playbackStart + segmentEnd - modificationStart;
-
-              if (start < playbackStart || start > playbackEnd) {
-                startElement.dataset.playbackStart = '';
-                startElement.dataset.playbackEnd = '';
-                textElement.dataset.playbackStart = '';
-                startElement.innerText = '';
-                endElement.innerText = '';
-              } else {
-                startElement.dataset.playbackStart = start;
-                endElement.dataset.playbackEnd = end;
-                textElement.dataset.playbackStart = start;
-                startElement.innerText = this.timestampToString(start);
-                endElement.innerText = this.timestampToString(end);
-              }
-            }
-          });
+          if (start >= playbackStart && start <= playbackEnd) {
+            // Found a playable region
+            isPlayable = true;
+            startElement.dataset.playbackStart = start;
+            endElement.dataset.playbackEnd = end;
+            textElement.dataset.playbackStart = start;
+            startElement.innerText = this.timestampToString(start);
+            endElement.innerText = this.timestampToString(end);
+            break; // We found a playable region, no need to check others
+          }
         }
-      }
+
+        // If no playable region found, clear the data
+        if (!isPlayable) {
+          startElement.dataset.playbackStart = '';
+          endElement.dataset.playbackEnd = '';
+          textElement.dataset.playbackStart = '';
+          startElement.innerText = '';
+          endElement.innerText = '';
+        }
+      });
     });
   }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -266,8 +266,8 @@ class App {
       const playbackEnd = pr.playbackEnd;
       const modificationStart = pr.modificationStart;
 
-      let start = playbackStart + segmentStart - modificationStart;
-      let end = playbackStart + segmentEnd - modificationStart;
+      const start = playbackStart + segmentStart - modificationStart;
+      const end = playbackStart + segmentEnd - modificationStart;
 
       if (start >= playbackStart && start <= playbackEnd) {
         return { start, end };

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -410,8 +410,10 @@ class App {
   }
 
   playSegment(segment) {
-    const playbackStart = parseFloat(segment.dataset.playbackStart);
-    this.playAt(playbackStart);
+    if (segment.dataset.playbackStart) {
+      const playbackStart = parseFloat(segment.dataset.playbackStart);
+      this.playAt(playbackStart);
+    }
   }
 
   playAt(seconds) {


### PR DESCRIPTION
This change fixes the auto-play behavior when there are multiple playback regions (i.e. media items) that refer to the same audio source.

Previously, the last playback region would overwrite any playback data found earlier in the project, resulting in segments that won't auto-play even though it would be possible to do so.

Instead, we can build a mapping from audio source to collections of playback regions. For a given segment, we can use its audio source to find its corresponding playback regions, and link to the first playable region. This could later be expanded to allow playing any playable region, if there are multiple candidates.

With this change, auto-play links work more effectively when media items are split, cropped, duplicated, and otherwise rearranged in the project.