### PR TITLE
More app tests

### DIFF
--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -71,6 +71,7 @@ export default class App {
       this.state = JSON.parse(window.__JUCE__.initialisationData.webState[0]);
     } catch (e) {
       console.warn('Failed to parse web state:', e);
+      this.showAlert('danger', '<b>Error:</b> Failed to read project data!');
     }
     return Promise.resolve();
   }

--- a/source/ts/tests/App.test.ts
+++ b/source/ts/tests/App.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import App from '../src/App';
+import fs from 'fs';
 import mockNative from './mocks/MockNative';
+import path from 'path';
 
 describe('App', () => {
   // Spy on console.warn
@@ -15,6 +17,10 @@ describe('App', () => {
         webState: ['']
       }
     };
+
+    const htmlPath = path.resolve(__dirname, '../../../assets/index.html');
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    document.documentElement.innerHTML = html;
   });
 
   afterEach(() => {
@@ -23,6 +29,7 @@ describe('App', () => {
 
   it('constructs App', () => {
     const app = new App();
+
     expect(app.state.modelName).toBe('small');
     expect(app.state.language).toBe('');
     expect(app.state.translate).toBe(false);
@@ -36,7 +43,9 @@ describe('App', () => {
       translate: true,
       transcript: null
     })];
+
     const app = new App();
+
     app.loadState().then(() => {
       expect(app.state.modelName).toBe('medium');
       expect(app.state.language).toBe('fr');
@@ -45,23 +54,54 @@ describe('App', () => {
     });
   });
 
-  it('handles initial webState when loading state', async () => {
+  it('loads state with transcript', () => {
+    const transcript = {
+      groups: [{
+        segments: [{ text: 'test', start: 0, end: 1 }],
+        audioSource: { persistentID: 'audio1', name: 'Audio 1' }
+      }]
+    };
+
+    window.__JUCE__.initialisationData.webState = [JSON.stringify({
+      modelName: 'medium',
+      language: 'fr',
+      translate: true,
+      transcript: transcript
+    })];
+
+    const app = new App();
+
+    app.loadState().then(() => {
+      expect(app.state.modelName).toBe('medium');
+      expect(app.state.language).toBe('fr');
+      expect(app.state.translate).toBe(true);
+      expect(app.state.transcript).toEqual(transcript);
+    });
+  });
+
+  it('handles missing state', async () => {
+    window.__JUCE__.initialisationData.webState = undefined;
+
     const app = new App();
     await app.loadState();
-    expect(app.state.modelName).toBe('small');
+
     expect(app.state.language).toBe('');
     expect(app.state.translate).toBe(false);
     expect(app.state.transcript).toBeNull();
+
+    expect(warnSpy).toHaveBeenCalled();
   });
 
   it('handles invalid JSON when loading state', async () => {
     window.__JUCE__.initialisationData.webState = ['invalid'];
+
     const app = new App();
     await app.loadState();
-    expect(app.state.modelName).toBe('small');
+
     expect(app.state.language).toBe('');
     expect(app.state.translate).toBe(false);
     expect(app.state.transcript).toBeNull();
+
     expect(warnSpy).toHaveBeenCalled();
   });
 
@@ -80,5 +120,264 @@ describe('App', () => {
     const newState = JSON.parse(newStateJSON);
     expect(newState.modelName).toBe('large');
     expect(newState.language).toBe('de');
+  });
+
+  it('does not crash if app.state is null when saving state', async () => {
+    const app = new App();
+    app.state = null;
+    await app.saveState();
+    expect(mockNative.setWebState).not.toHaveBeenCalled();
+  });
+
+  it('initializes models correctly', async () => {
+    const mockModels = [
+      { name: 'small', label: 'Small' },
+      { name: 'medium', label: 'Medium' }
+    ];
+    mockNative.getModels.mockResolvedValue(mockModels);
+
+    const app = new App();
+    await app.initModels();
+
+    expect(mockNative.getModels).toHaveBeenCalled();
+
+    const select = document.getElementById('model-select') as HTMLSelectElement;
+    expect(select.options[0].value).toBe('small');
+    expect(select.options[0].textContent).toBe('Small');
+    expect(select.options[1].value).toBe('medium');
+    expect(select.options[1].textContent).toBe('Medium');
+  });
+
+  it('initializes languages correctly', async () => {
+    const mockLanguages = [
+      { code: 'en', name: 'english' },
+      { code: 'fr', name: 'french' }
+    ];
+    mockNative.getWhisperLanguages.mockResolvedValue(mockLanguages);
+
+    const app = new App();
+    await app.initLanguages();
+
+    expect(mockNative.getWhisperLanguages).toHaveBeenCalled();
+
+    const select = document.getElementById('language-select') as HTMLSelectElement;
+    expect(select.options[0].value).toBe('');
+    expect(select.options[0].textContent).toBe('Detect');
+    expect(select.options[1].value).toBe('en');
+    expect(select.options[1].textContent).toBe('English');
+    expect(select.options[2].value).toBe('fr');
+    expect(select.options[2].textContent).toBe('French');
+  });
+
+  it('initializes transcript grid correctly', () => {
+    const app = new App();
+
+    app.state.transcript = {
+      groups: [{
+        segments: [{ text: 'test', start: 0, end: 1 }],
+        audioSource: { persistentID: 'audio1', name: 'Audio 1' }
+      }]
+    };
+
+    app.initTranscriptGrid();
+
+    const rows = app.transcriptGrid.getRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].playbackStart).toBe(0);
+    expect(rows[0].playbackEnd).toBe(1);
+    expect(rows[0].text).toBe('test');
+    expect(rows[0].source).toBe('Audio 1');
+    expect(rows[0].sourceID).toBe('audio1');
+  });
+
+  it('handles model selection change', async () => {
+    const mockModels = [
+      { name: 'small', label: 'Small' },
+      { name: 'medium', label: 'Medium' }
+    ];
+    mockNative.getModels.mockResolvedValue(mockModels);
+
+    const app = new App();
+    const mockSaveState = jest.spyOn(app, 'saveState').mockImplementation(() => Promise.resolve());
+    await app.initModels();
+
+    const select = document.getElementById('model-select') as HTMLSelectElement;
+    select.selectedIndex = 1;
+
+    await app.handleModelChange();
+
+    expect(app.state.modelName).toBe('medium');
+    expect(mockSaveState).toHaveBeenCalled();
+
+    mockSaveState.mockRestore();
+  });
+
+  it('handles language selection change', async () => {
+    const mockLanguages = [
+      { code: 'en', name: 'english' },
+      { code: 'fr', name: 'french' }
+    ];
+    mockNative.getWhisperLanguages.mockResolvedValue(mockLanguages);
+
+    const app = new App();
+    const mockSaveState = jest.spyOn(app, 'saveState').mockImplementation(() => Promise.resolve());
+    await app.initLanguages();
+
+    const select = document.getElementById('language-select') as HTMLSelectElement;
+    select.selectedIndex = 2;
+
+    await app.handleLanguageChange();
+
+    expect(app.state.language).toBe('fr');
+    expect(mockSaveState).toHaveBeenCalled();
+
+    mockSaveState.mockRestore();
+  });
+
+  it('handles translate checkbox change', async () => {
+    const app = new App();
+    const mockSaveState = jest.spyOn(app, 'saveState').mockImplementation(() => Promise.resolve());
+
+    const checkbox = document.getElementById('translate-checkbox') as HTMLInputElement;
+    checkbox.checked = true;
+
+    await app.handleTranslateChange();
+
+    expect(app.state.translate).toBe(true);
+    expect(mockSaveState).toHaveBeenCalled();
+
+    mockSaveState.mockRestore();
+  });
+
+  it('handles process button click', async () => {
+    const app = new App();
+
+    (app as any).transcriptGrid = {
+      addSegments: jest.fn(),
+      clear: jest.fn()
+    };
+
+    const audioSource1 = { persistentID: 'audio1', name: 'Audio 1' };
+    const audioSource2 = { persistentID: 'audio2', name: 'Audio 2' };
+
+    mockNative.getAudioSources.mockResolvedValue([
+      audioSource1,
+      audioSource2
+    ]);
+
+    const segments = [{ text: 'test', start: 0, end: 1 }];
+
+    mockNative.transcribeAudioSource.mockResolvedValue({ segments });
+
+    await app.handleProcess();
+
+    expect(app.transcriptGrid.clear).toHaveBeenCalled();
+    expect(app.transcriptGrid.addSegments).toHaveBeenCalledTimes(2);
+    expect(app.transcriptGrid.addSegments).toHaveBeenCalledWith(segments, audioSource1);
+    expect(app.transcriptGrid.addSegments).toHaveBeenCalledWith(segments, audioSource2);
+    expect(app.state.transcript).toEqual({
+      groups: [
+        { segments, audioSource: audioSource1 },
+        { segments, audioSource: audioSource2 }
+      ]
+    });
+  });
+
+  it('handles process errors', async () => {
+    const app = new App();
+
+    (app as any).transcriptGrid = {
+      addSegments: jest.fn(),
+      clear: jest.fn()
+    };
+
+    const audioSource = { persistentID: 'audio1', name: 'Audio 1' };
+    mockNative.getAudioSources.mockResolvedValue([audioSource]);
+
+    const error = 'Test error';
+    mockNative.transcribeAudioSource.mockResolvedValue({ error });
+
+    await app.handleProcess();
+
+    expect(app.transcriptGrid.clear).toHaveBeenCalled();
+    expect(app.transcriptGrid.addSegments).not.toHaveBeenCalled();
+    expect(app.state.transcript).toBeNull();
+
+    const alerts = document.getElementById('alerts') as HTMLElement;
+    expect(alerts.innerHTML).toContain(error);
+  });
+
+  it('clears transcript correctly', async () => {
+    const app = new App();
+
+    (app as any).transcriptGrid = {
+      clear: jest.fn()
+    };
+
+    app.state.transcript = { groups: [] };
+
+    await app.clearTranscript();
+
+    expect(app.transcriptGrid.clear).toHaveBeenCalled();
+    expect(app.state.transcript).toBeNull();
+  });
+
+  it('creates markers correctly', async () => {
+    const app = new App();
+
+    (app as any).transcriptGrid = {
+      getRows: jest.fn().mockReturnValue([
+        { playbackStart: 0, playbackEnd: 1, text: 'Test 1' },
+        { playbackStart: 2, playbackEnd: 3, text: 'Test 2' }
+      ])
+    };
+
+    await app.handleCreateMarkers('markers');
+
+    expect(mockNative.createMarkers).toHaveBeenCalledWith([
+      { start: 0, end: 1, name: 'Test 1' },
+      { start: 2, end: 3, name: 'Test 2' }
+    ], 'markers');
+  });
+
+  it('does not call createMarkers if there are no rows', async () => {
+    const app = new App();
+
+    (app as any).transcriptGrid = {
+      getRows: jest.fn().mockReturnValue([])
+    };
+
+    await app.handleCreateMarkers('markers');
+
+    expect(mockNative.createMarkers).not.toHaveBeenCalled();
+  });
+
+  it('handles errors creating markers', async () => {
+    const app = new App();
+
+    (app as any).transcriptGrid = {
+      getRows: jest.fn().mockReturnValue([
+        { playbackStart: 0, playbackEnd: 1, text: 'Test 1' }
+      ])
+    };
+
+    const error = 'Test error';
+    mockNative.createMarkers.mockResolvedValue({ error });
+
+    await app.handleCreateMarkers('markers');
+
+    const alerts = document.getElementById('alerts') as HTMLElement;
+    expect(alerts.innerHTML).toContain(error);
+  });
+
+  it('plays at a given time', async () => {
+    const app = new App();
+    const seconds = 10;
+
+    await app.playAt(seconds);
+
+    expect(mockNative.stop).toHaveBeenCalled();
+    expect(mockNative.setPlaybackPosition).toHaveBeenCalledWith(seconds);
+    expect(mockNative.play).toHaveBeenCalled();
   });
 });

--- a/source/ts/tests/App.test.ts
+++ b/source/ts/tests/App.test.ts
@@ -103,6 +103,9 @@ describe('App', () => {
     expect(app.state.transcript).toBeNull();
 
     expect(warnSpy).toHaveBeenCalled();
+
+    const alerts = document.getElementById('alerts') as HTMLElement;
+    expect(alerts.innerHTML).toContain('Failed to read project data');
   });
 
   it('saves state', async () => {

--- a/source/ts/tests/App.test.ts
+++ b/source/ts/tests/App.test.ts
@@ -322,6 +322,34 @@ describe('App', () => {
     expect(app.state.transcript).toBeNull();
   });
 
+  it('collects playback regions by audio source', () => {
+    const app = new App();
+
+    const region1 = { playbackStart: 0, playbackEnd: 1, modificationStart: 0, modificationEnd: 1, audioSourcePersistentID: 'audio1' };
+    const region2 = { playbackStart: 2, playbackEnd: 3, modificationStart: 2, modificationEnd: 3, audioSourcePersistentID: 'audio1' };
+    const region3 = { playbackStart: 4, playbackEnd: 5, modificationStart: 4, modificationEnd: 5, audioSourcePersistentID: 'audio2' };
+    const region4 = { playbackStart: 6, playbackEnd: 7, modificationStart: 6, modificationEnd: 7, audioSourcePersistentID: 'audio2' };
+
+    const regionSequences = [
+      {
+        name: 'Track 1',
+        orderIndex: 0,
+        playbackRegions: [region1, region2, region3]
+      },
+      {
+        name: 'Track 2',
+        orderIndex: 1,
+        playbackRegions: [region4]
+      }
+    ];
+
+    const regions = app.collectPlaybackRegionsByAudioSource(regionSequences);
+
+    expect(regions.size).toBe(2);
+    expect(regions.get('audio1')).toEqual([region1, region2]);
+    expect(regions.get('audio2')).toEqual([region3, region4]);
+  });
+
   it('creates markers correctly', async () => {
     const app = new App();
 

--- a/source/ts/tests/mocks/MockNative.ts
+++ b/source/ts/tests/mocks/MockNative.ts
@@ -5,17 +5,32 @@ export class MockNative {
   private mockFunctions: Map<string, jest.Mock> = new Map();
 
   // Common native functions exposed as properties
+  public canCreateMarkers: jestMock;
+  public createMarkers: jestMock;
+  public getAudioSources: jest.Mock;
   public getModels: jest.Mock;
+  public getWhisperLanguages: jest.Mock;
+  public play: jest.Mock;
+  public setPlaybackPosition: jest.Mock;
   public setWebState: jest.Mock;
-  // Add other common functions here
+  public stop: jest.Mock;
+  public transcribeAudioSource: jest.Mock;
 
   constructor() {
     // Setup the global Juce.getNativeFunction mock
     this.setupJuceNativeFunctionMock();
 
     // Initialize common mocks (without setting defaults yet)
+    this.canCreateMarkers = this.createMock('canCreateMarkers');
+    this.createMarkers = this.createMock('createMarkers');
+    this.getAudioSources = this.createMock('getAudioSources');
     this.getModels = this.createMock('getModels');
+    this.getWhisperLanguages = this.createMock('getWhisperLanguages');
+    this.play = this.createMock('play');
+    this.setPlaybackPosition = this.createMock('setPlaybackPosition');
     this.setWebState = this.createMock('setWebState');
+    this.stop = this.createMock('stop');
+    this.transcribeAudioSource = this.createMock('transcribeAudioSource');
 
     // Initialize all mocks with their default values
     this.reset();
@@ -68,10 +83,16 @@ export class MockNative {
     });
 
     // Set default implementations for common mocks
+    this.canCreateMarkers.mockReturnValue(Promise.resolve(true));
+    this.createMarkers.mockReturnValue(Promise.resolve());
+    this.getAudioSources.mockReturnValue(Promise.resolve([]));
     this.getModels.mockReturnValue(Promise.resolve([]));
+    this.getWhisperLanguages.mockReturnValue(Promise.resolve([]));
+    this.play.mockReturnValue(Promise.resolve());
+    this.setPlaybackPosition.mockReturnValue(Promise.resolve());
     this.setWebState.mockReturnValue(Promise.resolve());
-
-    // Add defaults for any other mocks here
+    this.stop.mockReturnValue(Promise.resolve());
+    this.transcribeAudioSource.mockReturnValue(Promise.resolve({"segments": []}));
   }
 }
 

--- a/source/ts/tests/mocks/MockNative.ts
+++ b/source/ts/tests/mocks/MockNative.ts
@@ -5,8 +5,8 @@ export class MockNative {
   private mockFunctions: Map<string, jest.Mock> = new Map();
 
   // Common native functions exposed as properties
-  public canCreateMarkers: jestMock;
-  public createMarkers: jestMock;
+  public canCreateMarkers: jest.Mock;
+  public createMarkers: jest.Mock;
   public getAudioSources: jest.Mock;
   public getModels: jest.Mock;
   public getWhisperLanguages: jest.Mock;


### PR DESCRIPTION
This is a follow-up to #20 that more thoroughly tests the `App` class. A few changes were needed to make `App` more amenable to testing, primarily around the use of Promises.

Switched to using `textContent` instead of `innerText`, since the latter is apparently non-trivial and not supported by jsdom.