### PR TITLE
Build against static CUDA runtime on Windows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -55,7 +55,7 @@ jobs:
             os: windows-latest
             cuda: true
             cuda-version: '12.8.0'
-            extra-flags: -DGGML_CUDA=1
+            extra-flags: -DGGML_CUDA=1 -DGGML_STATIC=1
 
     steps:
       - name: Maximize build space


### PR DESCRIPTION
This change adds a build flag, `GGML_STATIC=1`, to the Windows CUDA build, which enables linking against the static CUDA runtime (cudart_static) instead of the dynamic cudart library.

According to a comment in whisper.cpp's CMake configuration, NVIDIA does not offer static versions of two other libraries that whisper.cpp uses on the Windows platform (though they do exist on Linux):

```
if (GGML_STATIC)
    if (WIN32)
        # As of 12.3.1 CUDA Toolkit for Windows does not offer a static cublas library
        target_link_libraries(ggml-cuda PRIVATE CUDA::cudart_static CUDA::cublas CUDA::cublasLt)
    else ()
        target_link_libraries(ggml-cuda PRIVATE  CUDA::cudart_static CUDA::cublas_static CUDA::cublasLt_static)
    endif()
else()
    target_link_libraries(ggml-cuda PRIVATE CUDA::cudart CUDA::cublas CUDA::cublasLt)
endif()
```

So, this does not get us to 100% static linking, but I'm hoping this will reduce the amount of CUDA version dependency, enabling better compatibility on Windows. My general understanding is that VSTs should use static linking as much as possible to avoid "DLL hell".

I didn't make a similar change for Linux yet, as I don't know if this flag actually improves anything. Needs more testing.