### PR TITLE
trigger after release status change

### DIFF
--- a/.github/workflows/send-release-notes-to-web.yml
+++ b/.github/workflows/send-release-notes-to-web.yml
@@ -5,6 +5,15 @@ on:
   release:
     types: [edited] # we currently manually set release to latest 
   workflow_dispatch: # add manual trigger
+    inputs:
+      release_name:
+        description: 'Test release name'
+        required: true
+        default: 'Test Release'
+      release_body:
+        description: 'Test release notes'
+        required: true
+        default: 'These are test release notes for manual triggering'
 
 jobs:
   publish-release-notes:
@@ -17,20 +26,21 @@ jobs:
 
       - name: Print release info
         run: |
-          echo "Release '${{ github.event.release.name }}' is now the latest release."
+          RELEASE_NAME="${{ github.event.release.name || github.event.inputs.release_name }}"
+          echo "Release '$RELEASE_NAME' is now the latest release."
           echo "Release URL: ${{ github.event.release.html_url }}"
 
       - name: Set RELEASE_NOTES environment variable
         run: |
-          
+          RELEASE_BODY="${{ github.event.release.body || github.event.inputs.release_body }}"
           # save release notes to environment
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_ENV"
-          echo "${{ github.event.release.body }}" >> "$GITHUB_ENV"
+          echo "$RELEASE_BODY" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
 
           # print release notes
           echo "Release notes:"
-          echo "${{ github.event.release.body }}"
+          echo "$RELEASE_BODY"
       
       
       - name: Create JSON payload

--- a/.github/workflows/send-release-notes-to-web.yml
+++ b/.github/workflows/send-release-notes-to-web.yml
@@ -27,6 +27,10 @@ jobs:
           echo "RELEASE_NOTES<<EOF" >> "$GITHUB_ENV"
           echo "${{ github.event.release.body }}" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
+
+          # print release notes
+          echo "Release notes:"
+          echo "${{ github.event.release.body }}"
       
       
       - name: Create JSON payload

--- a/.github/workflows/send-release-notes-to-web.yml
+++ b/.github/workflows/send-release-notes-to-web.yml
@@ -1,17 +1,24 @@
 name: Publish GitHub Release Notes to website repo to create blog post
+# Trigger when a new release changes from pre-release to latest
 
 on:
   release:
-    types: [published]  
-    workflow_dispatch:
+    types: [edited] # we currently manually set release to latest 
+  workflow_dispatch: # add manual trigger
 
 jobs:
   publish-release-notes:
     runs-on: ubuntu-latest
+    if: ${{ github.event.release.prerelease == false }} 
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Print release info
+        run: |
+          echo "Release '${{ github.event.release.name }}' is now the latest release."
+          echo "Release URL: ${{ github.event.release.html_url }}"
 
       - name: Set RELEASE_NOTES environment variable
         run: |


### PR DESCRIPTION
Updated workflow to trigger after an edit when not a prerelease.  This should trigger when changing to latest status.