### PR TITLE
attempt to run "npm run build" (if necessary) from CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,17 @@ include(Assets)
 set(REQUIRED_JS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/assets/js/main.js")
 list(FIND AssetFiles "${REQUIRED_JS_FILE}" JS_FILE_INDEX)
 if(JS_FILE_INDEX EQUAL -1)
-    message(FATAL_ERROR "Missing required file: ${REQUIRED_JS_FILE}\nPlease run 'npm run build' from the 'source/ts' directory before building.")
+    message("Missing required file: ${REQUIRED_JS_FILE}, running 'npm run build' from 'source/ts' directory")
+    execute_process(COMMAND npm run build
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/source/ts"
+        RESULT_VARIABLE BUILD_RESULT
+        OUTPUT_VARIABLE BUILD_OUTPUT
+        ERROR_VARIABLE BUILD_ERROR
+    )
+    message(STATUS "Build output: ${BUILD_OUTPUT}")
+    if(BUILD_RESULT)
+        message(FATAL_ERROR "Failed to build JS files: ${BUILD_ERROR}")
+    endif()
 endif()
 
 # MacOS only: Cleans up folder and target organization on Xcode.


### PR DESCRIPTION
This replaces the fatal error encountered when the built JS file isn't available with an attempt to run `npm run build` directly. Output is stored and printed, and if there's a problem _then_ we go the fatal error route.