### PR TITLE
Add cmake flag to enable building web assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.25)
 
 # This tells cmake we have goodies in the /cmake folder
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake-local")
 include(PamplejuceVersion)
 
 # Modern concise way to add dependencies to your project
@@ -142,15 +143,7 @@ set(SourceFiles source/reaper/IReaperHostApplication.cpp source/Main.cpp)
 # file(GLOB_RECURSE SourceFiles CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/source/*.h")
 target_sources(SharedCode INTERFACE ${SourceFiles})
 
-# Adds a BinaryData target for embedding assets into the binary
-include(Assets)
-
-# Check if the required JS file exists in the asset files
-set(REQUIRED_JS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/assets/js/main.js")
-list(FIND AssetFiles "${REQUIRED_JS_FILE}" JS_FILE_INDEX)
-if(JS_FILE_INDEX EQUAL -1)
-    message(FATAL_ERROR "Missing required file: ${REQUIRED_JS_FILE}\nPlease run 'npm run build' from the 'source/ts' directory before building.")
-endif()
+include(WebAssets)
 
 # MacOS only: Cleans up folder and target organization on Xcode.
 include(XcodePrettify)

--- a/cmake-local/WebAssets.cmake
+++ b/cmake-local/WebAssets.cmake
@@ -1,0 +1,63 @@
+# Option to build web assets
+option(BUILD_WEB_ASSETS "Build web assets using npm" OFF)
+
+# Check for JS file or build it if BUILD_WEB_ASSETS is ON
+set(REQUIRED_JS_FILE "${CMAKE_CURRENT_SOURCE_DIR}/assets/js/main.js")
+
+if(BUILD_WEB_ASSETS)
+    # Find npm executable
+    find_program(NPM_EXECUTABLE npm)
+    if(NOT NPM_EXECUTABLE)
+        message(FATAL_ERROR "npm not found but BUILD_WEB_ASSETS is ON")
+    endif()
+
+    # Run npm commands at configure time to ensure main.js exists before the Assets glob
+    if(WIN32)
+        execute_process(
+            COMMAND cmd /c ${NPM_EXECUTABLE} install
+            COMMAND cmd /c ${NPM_EXECUTABLE} run build
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/source/ts"
+            RESULT_VARIABLE NPM_RESULT
+        )
+    else()
+        execute_process(
+            COMMAND ${NPM_EXECUTABLE} install
+            COMMAND ${NPM_EXECUTABLE} run build
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/source/ts"
+            RESULT_VARIABLE NPM_RESULT
+        )
+    endif()
+
+    if(NOT NPM_RESULT EQUAL 0)
+        message(FATAL_ERROR "Failed to build web assets")
+    endif()
+endif()
+
+# Now include Assets after we've potentially created main.js
+include(Assets)
+
+if(BUILD_WEB_ASSETS)
+    # Create rebuild target for subsequent builds
+    if(WIN32)
+        add_custom_target(BuildWebAssets
+            COMMAND cmd /c ${NPM_EXECUTABLE} run build
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/source/ts"
+            COMMENT "Building web assets..."
+        )
+    else()
+        add_custom_target(BuildWebAssets
+            COMMAND ${NPM_EXECUTABLE} run build
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/source/ts"
+            COMMENT "Building web assets..."
+        )
+    endif()
+
+    # Make Assets depend on the rebuild target
+    add_dependencies(Assets BuildWebAssets)
+else()
+    # Check if main.js exists when not building
+    list(FIND AssetFiles "${REQUIRED_JS_FILE}" JS_FILE_INDEX)
+    if(JS_FILE_INDEX EQUAL -1)
+        message(FATAL_ERROR "Missing required file: ${REQUIRED_JS_FILE}\nPlease run 'npm run build' from the 'source/ts' directory before building.")
+    endif()
+endif()


### PR DESCRIPTION
This change adds the ability to run `npm install` and `npm run build` from cmake by running cmake with the following options:

```
cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBUILD_WEB_ASSETS=1
```

This is a second attempt at implementing the idea in PR #34, which was accidentally reverted. There are a few differences from this first attempt:

- The feature is behind a cmake option so that it does not interfere with the current GitHub workflow
- A new include directory, "cmake-local", is added so that CMakeLists.txt can be decomposed
- Workarounds are in place for Windows, where npm may be an "npm.cmd" command, and cmake struggles with this
- If main.js does not exist, and BUILD_WEB_ASSETS is enabled, it is created before including Pamplejuce's Assets.cmake, which uses a glob that depends on all the assets existing before it is included
- A WebAssets target is added as a dependency so that web assets are rebuilt every time, ensuring that TS code changes are included