### PR TITLE
reverted blog date format to YYYY-MM-DD

### DIFF
--- a/.github/workflows/send-release-notes-to-web.yml
+++ b/.github/workflows/send-release-notes-to-web.yml
@@ -49,7 +49,7 @@ jobs:
           # Extract repository name 
           REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
             
-          CURRENT_DATE=$(date +'%Y%m%d')
+          CURRENT_DATE=$(date +'%Y-%m-%d')
           RELEASE_TAG="${{ github.event.release.tag_name || 'manual-test-tag' }}"
 
           # Construct proper repository_dispatch payload


### PR DESCRIPTION
Handling this separately in the receiving workflow for naming purposes and keeping as is for the actual post creation.