### PR TITLE
Enable transcription to be cancelled

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -40,6 +40,7 @@
 
         <button id="process-button" class="btn btn-primary" type="button" style="min-width: 170px">
           <span id="spinner" class="spinner-border spinner-border-sm" role="status" aria-hidden="true" style="display: none"></span>
+          <span id="process-cancel" style="display: none">Cancel</span>
           <span id="process-text">Process</span>
         </button>
       </div>

--- a/source/asr/ASRThreadPoolJob.h
+++ b/source/asr/ASRThreadPoolJob.h
@@ -68,7 +68,7 @@ public:
         DBG ("Downloading model");
         onStatusCallback (ASRThreadPoolJobStatus::downloadingModel);
 
-        if (! asrEngine.downloadModel (options->modelName.toStdString()))
+        if (! asrEngine.downloadModel (options->modelName.toStdString(), [this] { return shouldExit(); }))
         {
             onStatusCallback (ASRThreadPoolJobStatus::failed);
             onCompleteCallback ({ true, "Failed to download model", {} });

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -219,12 +219,17 @@ export default class App {
 
   handleCancel() {
     this.processing = false;
-    this.setProcessText('Process');
     this.hideCancel();
     this.hideSpinner();
     this.hideTranscript();
 
+    this.disableProcessButton();
+    this.setProcessText('Canceling...');
+
     return this.native.abortTranscription().then(() => {
+      this.enableProcessButton();
+      this.setProcessText('Process');
+
       return this.clearTranscript();
     });
   }
@@ -301,6 +306,14 @@ export default class App {
 
   setProcessText(text) {
     document.getElementById('process-text').innerText = text;
+  }
+
+  enableProcessButton() {
+    (document.getElementById('process-button') as HTMLButtonElement).disabled = false;
+  }
+
+  disableProcessButton() {
+    (document.getElementById('process-button') as HTMLButtonElement).disabled = true;
   }
 
   showCancel() {

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -16,9 +16,9 @@ declare global {
 
 export default class App {
   private native: Native;
-  private processing: boolean = false;
-  public transcriptGrid: TranscriptGrid;
+  public processing: boolean = false;
   public state: any;
+  public transcriptGrid: TranscriptGrid;
 
   constructor() {
     this.native = new Native();

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -167,7 +167,7 @@ export default class App {
   }
 
   handleProcess() {
-    this.processing = true
+    this.processing = true;
     this.showSpinner();
     this.setProcessText('Processing...');
     this.clearTranscript();
@@ -226,7 +226,13 @@ export default class App {
     this.disableProcessButton();
     this.setProcessText('Canceling...');
 
-    return this.native.abortTranscription().then(() => {
+    return this.native.abortTranscription().then((success) => {
+      if (!success) {
+        console.warn('Timed out trying to abort transcription job! Retrying...');
+        setTimeout(() => { this.handleCancel(); }, 1000);
+        return Promise.resolve();
+      }
+
       this.enableProcessButton();
       this.setProcessText('Process');
 
@@ -267,6 +273,9 @@ export default class App {
   }
 
   updateTranscriptionStatus() {
+    if (!this.processing) {
+      return Promise.resolve();
+    }
     return this.native.getTranscriptionStatus().then((status) => {
       if (status.status !== '') {
         this.setProcessText(status.status + '...');

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -217,7 +217,7 @@ export default class App {
     });
   }
 
-  handleCancel() {
+  handleCancel(retriesLeft = 100) {
     this.processing = false;
     this.hideCancel();
     this.hideSpinner();
@@ -226,10 +226,14 @@ export default class App {
     this.disableProcessButton();
     this.setProcessText('Canceling...');
 
-    return this.native.abortTranscription().then((success) => {
+    return this.native.abortTranscription().then((success: boolean) => {
       if (!success) {
-        console.warn('Timed out trying to abort transcription job! Retrying...');
-        return delay(1000).then(() => this.handleCancel());
+        if (retriesLeft > 0) {
+          console.warn('Timed out trying to abort transcription job! Retrying...');
+          return delay(1000).then(() => this.handleCancel(retriesLeft - 1));
+        } else {
+          this.showAlert('warning', '<b>Warning:</b> Unable to cancel transcription!');
+        }
       }
 
       this.enableProcessButton();

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -1,7 +1,7 @@
 import Native from './Native';
 import TranscriptGrid from './TranscriptGrid';
 import { AudioSource, PlaybackRegion, RegionSequence } from './ARA';
-import { htmlEscape, timestampToString } from './Utils';
+import { delay, htmlEscape } from './Utils';
 
 declare global {
   interface Window {
@@ -229,8 +229,7 @@ export default class App {
     return this.native.abortTranscription().then((success) => {
       if (!success) {
         console.warn('Timed out trying to abort transcription job! Retrying...');
-        setTimeout(() => { this.handleCancel(); }, 1000);
-        return Promise.resolve();
+        return delay(1000).then(() => this.handleCancel());
       }
 
       this.enableProcessButton();

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -57,18 +57,11 @@ export default class App {
 
     document.getElementById('process-button').onmouseover = () => {
       if (!this.processing) return;
-
-      document.getElementById('process-button').classList.add('btn-danger');
-      document.getElementById('process-button').classList.remove('btn-primary');
-      document.getElementById('process-cancel').style.display = 'inline-block';
-      document.getElementById('process-text').style.display = 'none';
+      this.showCancel();
     };
 
     document.getElementById('process-button').onmouseout = () => {
-      document.getElementById('process-button').classList.add('btn-primary');
-      document.getElementById('process-button').classList.remove('btn-danger');
-      document.getElementById('process-cancel').style.display = 'none';
-      document.getElementById('process-text').style.display = 'inline-block';
+      this.hideCancel();
     };
   }
 
@@ -193,8 +186,9 @@ export default class App {
       const processNextAudioSource = () => {
         if (audioSources.length === 0) {
           this.processing = false;
-          this.hideSpinner();
           this.setProcessText('Process');
+          this.hideCancel();
+          this.hideSpinner();
           return this.saveState();
         }
 
@@ -226,6 +220,7 @@ export default class App {
   handleCancel() {
     this.processing = false;
     this.setProcessText('Process');
+    this.hideCancel();
     this.hideSpinner();
     this.hideTranscript();
 
@@ -306,6 +301,20 @@ export default class App {
 
   setProcessText(text) {
     document.getElementById('process-text').innerText = text;
+  }
+
+  showCancel() {
+    document.getElementById('process-button').classList.add('btn-danger');
+    document.getElementById('process-button').classList.remove('btn-primary');
+    document.getElementById('process-cancel').style.display = 'inline-block';
+    document.getElementById('process-text').style.display = 'none';
+  }
+
+  hideCancel() {
+    document.getElementById('process-button').classList.add('btn-primary');
+    document.getElementById('process-button').classList.remove('btn-danger');
+    document.getElementById('process-cancel').style.display = 'none';
+    document.getElementById('process-text').style.display = 'inline-block';
   }
 
   showSpinner() {

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -201,7 +201,11 @@ export default class App {
         const audioSource = audioSources.shift();
 
         return this.native.transcribeAudioSource(audioSource.persistentID, asrOptions).then((result) => {
-          if (this.processing && result.segments && result.segments.length > 0) {
+          if (!this.processing) {
+            return Promise.resolve();
+          }
+
+          if (result.segments && result.segments.length > 0) {
             this.showTranscript();
             this.transcriptGrid.addSegments(result.segments, audioSource);
             this.state.transcript = this.state.transcript || { groups: [] };

--- a/source/ts/src/Native.ts
+++ b/source/ts/src/Native.ts
@@ -1,6 +1,7 @@
 import * as Juce from "juce-framework-frontend";
 
 export default class Native {
+  abortTranscription = Juce.getNativeFunction("abortTranscription");
   canCreateMarkers = Juce.getNativeFunction("canCreateMarkers");
   createMarkers = Juce.getNativeFunction("createMarkers");
   getAudioSources = Juce.getNativeFunction("getAudioSources");

--- a/source/ts/src/Utils.ts
+++ b/source/ts/src/Utils.ts
@@ -1,4 +1,13 @@
 /**
+ * Delays execution for the specified number of milliseconds.
+ * @param ms The delay time in milliseconds.
+ * @returns A promise that resolves after the specified delay.
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
  * Escapes HTML special characters in a string.
  * @param str The string to escape.
  * @returns The escaped string.

--- a/source/ts/tests/App.test.ts
+++ b/source/ts/tests/App.test.ts
@@ -434,6 +434,43 @@ describe('App', () => {
     });
   });
 
+  describe('cancellation', () => {
+    it('handles cancel button click', async () => {
+      const app = new App();
+      app.processing = true;
+
+      (app as any).transcriptGrid = {
+        clear: jest.fn()
+      };
+
+      await app.handleCancel();
+
+      expect(app.processing).toBe(false);
+      expect(mockNative.abortTranscription).toHaveBeenCalled();
+      expect(app.transcriptGrid.clear).toHaveBeenCalled();
+    });
+
+    it('retries if transcription abort fails', async () => {
+      const app = new App();
+      app.processing = true;
+
+      (app as any).transcriptGrid = {
+        clear: jest.fn()
+      };
+
+      // First call returns false (failure), second call returns true (success)
+      mockNative.abortTranscription
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+
+      await app.handleCancel();
+
+      expect(app.processing).toBe(false);
+      expect(mockNative.abortTranscription).toHaveBeenCalledTimes(2);
+      expect(app.transcriptGrid.clear).toHaveBeenCalled();
+    });
+  });
+
   describe('interaction with results', () => {
     it('collects playback regions by audio source', () => {
       const app = new App();

--- a/source/ts/tests/App.test.ts
+++ b/source/ts/tests/App.test.ts
@@ -263,15 +263,20 @@ describe('App', () => {
         progress: 75
       });
 
+      app.processing = true;
       await app.updateTranscriptionStatus();
 
       expect(mockNative.getTranscriptionStatus).toHaveBeenCalled();
       expect(mockSetProcessText).toHaveBeenCalledWith('Processing...');
 
       const progress = document.getElementById('progress');
-      const progressBar = progress.querySelector('.progress-bar') as HTMLElement;
-      expect(progress.getAttribute('aria-valuenow')).toBe('75');
-      expect(progressBar.style.width).toBe('75%');
+      if (progress) {
+        const progressBar = progress.querySelector('.progress-bar') as HTMLElement;
+        expect(progress.getAttribute('aria-valuenow')).toBe('75');
+        expect(progressBar.style.width).toBe('75%');
+      } else {
+        throw new Error('Progress element not found');
+      }
 
       mockSetProcessText.mockRestore();
     });
@@ -285,6 +290,7 @@ describe('App', () => {
         progress: 0
       });
 
+      app.processing = true;
       await app.updateTranscriptionStatus();
 
       expect(mockNative.getTranscriptionStatus).toHaveBeenCalled();

--- a/source/ts/tests/App.test.ts
+++ b/source/ts/tests/App.test.ts
@@ -10,6 +10,7 @@ describe('App', () => {
   let warnSpy: any;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     mockNative.reset();
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -25,6 +26,7 @@ describe('App', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     warnSpy.mockRestore();
   });
 
@@ -463,7 +465,14 @@ describe('App', () => {
         .mockResolvedValueOnce(false)
         .mockResolvedValueOnce(true);
 
-      await app.handleCancel();
+      // Start the cancel operation
+      const cancelPromise = app.handleCancel();
+
+      // Advance timers after each async operation
+      await jest.runAllTimersAsync();
+
+      // Wait for the cancel operation to complete
+      await cancelPromise;
 
       expect(app.processing).toBe(false);
       expect(mockNative.abortTranscription).toHaveBeenCalledTimes(2);

--- a/source/ts/tests/mocks/MockNative.ts
+++ b/source/ts/tests/mocks/MockNative.ts
@@ -5,6 +5,7 @@ export class MockNative {
   private mockFunctions: Map<string, jest.Mock> = new Map();
 
   // Common native functions exposed as properties
+  public abortTranscription: jest.Mock;
   public canCreateMarkers: jest.Mock;
   public createMarkers: jest.Mock;
   public getAudioSources: jest.Mock;
@@ -24,6 +25,7 @@ export class MockNative {
     this.setupJuceNativeFunctionMock();
 
     // Initialize common mocks (without setting defaults yet)
+    this.abortTranscription = this.createMock('abortTranscription');
     this.canCreateMarkers = this.createMock('canCreateMarkers');
     this.createMarkers = this.createMock('createMarkers');
     this.getAudioSources = this.createMock('getAudioSources');
@@ -89,6 +91,7 @@ export class MockNative {
     });
 
     // Set default implementations for common mocks
+    this.abortTranscription.mockReturnValue(Promise.resolve(true));
     this.canCreateMarkers.mockReturnValue(Promise.resolve(true));
     this.createMarkers.mockReturnValue(Promise.resolve());
     this.getAudioSources.mockReturnValue(Promise.resolve([]));

--- a/source/ui/NativeFunctions.h
+++ b/source/ui/NativeFunctions.h
@@ -16,6 +16,7 @@
 #include "../plugin/ReaSpeechLiteAudioProcessorImpl.h"
 #include "../reaper/ReaperProxy.h"
 #include "../types/MarkerType.h"
+#include "../utils/AbortHandler.h"
 #include "../utils/SafeUTF8.h"
 
 class NativeFunctions : public OptionsBuilder<juce::WebBrowserComponent::Options>
@@ -62,8 +63,8 @@ public:
 
     void abortTranscription (const juce::var&, std::function<void (const juce::var&)> complete)
     {
-        bool success = threadPool.removeAllJobs (true, abortTimeout);
-        complete (juce::var (success));
+        threadPool.removeAllJobs (true, 0); // Non-blocking call to initiate job removal
+        new AbortHandler (threadPool, complete, abortTimeout);
     }
 
     void canCreateMarkers (const juce::var&, std::function<void (const juce::var&)> complete)

--- a/source/ui/NativeFunctions.h
+++ b/source/ui/NativeFunctions.h
@@ -30,6 +30,9 @@ public:
         asrEngine = std::make_unique<ASREngine> (Config::getModelsDir());
     }
 
+    // Timeout in milliseconds for aborting transcription jobs
+    static constexpr int abortTimeout = 60000;
+
     juce::WebBrowserComponent::Options buildOptions (const juce::WebBrowserComponent::Options& initialOptions)
     {
         auto bindFn = [this] (auto memberFn)
@@ -59,7 +62,7 @@ public:
 
     void abortTranscription (const juce::var&, std::function<void (const juce::var&)> complete)
     {
-        bool success = threadPool.removeAllJobs (true, 5000);
+        bool success = threadPool.removeAllJobs (true, abortTimeout);
         complete (juce::var (success));
     }
 

--- a/source/ui/NativeFunctions.h
+++ b/source/ui/NativeFunctions.h
@@ -41,6 +41,7 @@ public:
         };
 
         return initialOptions
+            .withNativeFunction ("abortTranscription", bindFn (&NativeFunctions::abortTranscription))
             .withNativeFunction ("canCreateMarkers", bindFn (&NativeFunctions::canCreateMarkers))
             .withNativeFunction ("createMarkers", bindFn (&NativeFunctions::createMarkers))
             .withNativeFunction ("getAudioSources", bindFn (&NativeFunctions::getAudioSources))
@@ -54,6 +55,12 @@ public:
             .withNativeFunction ("setPlaybackPosition", bindFn (&NativeFunctions::setPlaybackPosition))
             .withNativeFunction ("setWebState", bindFn (&NativeFunctions::setWebState))
             .withNativeFunction ("transcribeAudioSource", bindFn (&NativeFunctions::transcribeAudioSource));
+    }
+
+    void abortTranscription (const juce::var&, std::function<void (const juce::var&)> complete)
+    {
+        bool success = threadPool.removeAllJobs (true, 5000);
+        complete (juce::var (success));
     }
 
     void canCreateMarkers (const juce::var&, std::function<void (const juce::var&)> complete)
@@ -205,6 +212,7 @@ public:
                     progress = asrEngine->getProgress();
                 break;
             case ASRThreadPoolJobStatus::ready:
+            case ASRThreadPoolJobStatus::aborted:
             case ASRThreadPoolJobStatus::finished:
             case ASRThreadPoolJobStatus::failed:
                 break;

--- a/source/ui/NativeFunctions.h
+++ b/source/ui/NativeFunctions.h
@@ -31,7 +31,7 @@ public:
     }
 
     // Timeout in milliseconds for aborting transcription jobs
-    static constexpr int abortTimeout = 60000;
+    static constexpr int abortTimeout = 5000;
 
     juce::WebBrowserComponent::Options buildOptions (const juce::WebBrowserComponent::Options& initialOptions)
     {

--- a/source/utils/AbortHandler.h
+++ b/source/utils/AbortHandler.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <functional>
+
+#include <juce_core/juce_core.h>
+#include <juce_events/juce_events.h>
+
+class AbortHandler : public juce::Timer
+{
+public:
+    AbortHandler (juce::ThreadPool& pool, std::function<void (const juce::var&)> callback, int timeoutMs) :
+        threadPool (pool),
+        complete (callback),
+        startTime (juce::Time::getMillisecondCounter()),
+        timeout (static_cast<juce::uint32> (timeoutMs))
+    {
+        startTimer (50); // Check every 50ms
+    }
+
+    void timerCallback() override
+    {
+        auto now = juce::Time::getMillisecondCounter();
+        if (now - startTime > timeout)
+        {
+            // Timed out
+            complete (juce::var (false));
+            delete this;
+            return;
+        }
+
+        if (threadPool.getNumJobs() == 0)
+        {
+            // Successfully removed all jobs
+            complete (juce::var (true));
+            delete this;
+            return;
+        }
+    }
+
+private:
+    juce::ThreadPool& threadPool;
+    std::function<void (const juce::var&)> complete;
+    juce::uint32 startTime;
+    juce::uint32 timeout;
+};

--- a/source/utils/ResamplingExporter.h
+++ b/source/utils/ResamplingExporter.h
@@ -22,8 +22,13 @@ struct ResamplingExporter
      * @param destSampleRate The sample rate to which the audio data should be resampled.
      * @param channel The channel index to read from the audio source.
      * @param buffer A vector to store the resampled audio data.
+     * @param isAborted Optional callback that returns true if the operation should be aborted.
      */
-    static void exportAudio (juce::ARAAudioSource* audioSource, ARA::ARASampleRate destSampleRate, int channel, std::vector<float>& buffer)
+    static void exportAudio (juce::ARAAudioSource* audioSource,
+        ARA::ARASampleRate destSampleRate,
+        int channel,
+        std::vector<float>& buffer,
+        std::function<bool()> isAborted = nullptr)
     {
         const auto sourceChannelCount = audioSource->getChannelCount();
         jassert (channel >= 0 && channel < sourceChannelCount);
@@ -58,6 +63,9 @@ struct ResamplingExporter
         int destSamplePos = 0;
         while (destSamplePos < destSampleCount)
         {
+            if (isAborted && isAborted())
+                return;
+
             resamplingSource->getNextAudioBlock(channelInfo);
 
             // Copy the resampled block to the destination buffer


### PR DESCRIPTION
This change allows the user to interrupt a transcription, which is helpful when the process is taking a long time and the user no longer wants to continue.

whisper.cpp provides a callback mechanism where transcription can be interrupted between each chunk of processing. JUCE's ThreadPoolJob class supports cancellation, though this was not previously implemented in ASRThreadPoolJob. So, this change fixes that omission by checking the `shouldExit()` method at various steps in the process, and uses a callback function so that whisper.cpp can also invoke this `shouldExit()` method. After wiring this up, it is possible to cancel a running transcription by calling `removeAllJobs()` on the ThreadPool, which sends an exit signal (causing `shouldExit()` to return true) to any running jobs. A NativeFunction can simply call this method.

The UI was modified so that the Process button turns into a Cancel button on mouse-over. This replaces the previous behavior of disabling the button during processing.