### PR TITLE
Build for all CUDA architectures

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,7 +43,7 @@ jobs:
             os: ubuntu-22.04
             cuda: true
             cuda-version: '12.4.0'
-            extra-flags: -G Ninja -DGGML_CUDA=1 -DCMAKE_CUDA_ARCHITECTURES="50;60;61;70;75;80"
+            extra-flags: -G Ninja -DGGML_CUDA=1 -DCMAKE_CUDA_ARCHITECTURES=all
           - name: macOS
             os: macos-14
             pluginval-binary: pluginval.app/Contents/MacOS/pluginval
@@ -55,7 +55,7 @@ jobs:
             os: windows-latest
             cuda: true
             cuda-version: '12.4.0'
-            extra-flags: -DGGML_CUDA=1 -DGGML_STATIC=1 -DCMAKE_CUDA_ARCHITECTURES="50;60;61;70;75;80"
+            extra-flags: -DGGML_CUDA=1 -DGGML_STATIC=1 -DCMAKE_CUDA_ARCHITECTURES=all
 
     steps:
       - name: Maximize build space


### PR DESCRIPTION
This change enables building for all CUDA architectures, rather than a specific list.

Advantages:

- As many GPUs as possible are supported
- Much less likely that a user will need a C++ compiler to build CUDA code on the fly

Disadvantages:

- Much longer build times (going from 30-45 minutes to about 1.5 hours)
- Somewhat larger executables