### PR TITLE
Better pause handling

### DIFF
--- a/source/ts/src/TranscriptGrid.ts
+++ b/source/ts/src/TranscriptGrid.ts
@@ -224,11 +224,9 @@ export default class TranscriptGrid {
   ]);
 
   setPlaybackPosition(position: number, isPlaying: boolean) {
-    // Deselect all first
-    this.gridApi.deselectAll();
-
     // Don't select a row if not playing
     if (!isPlaying) {
+      this.gridApi.deselectAll();
       return;
     }
 
@@ -242,7 +240,8 @@ export default class TranscriptGrid {
 
     if (activeRow) {
       const node = this.gridApi.getRowNode(activeRow.id);
-      if (node) {
+      if (node && !node.isSelected()) {
+        this.gridApi.deselectAll();
         node.setSelected(true);
         this.gridApi.ensureNodeVisible(node);
       }

--- a/source/ts/tests/TranscriptGrid.test.ts
+++ b/source/ts/tests/TranscriptGrid.test.ts
@@ -192,6 +192,58 @@ describe('TranscriptGrid', () => {
     expect(grid.scoreColor(0)).toBe('transparent');
   });
 
+  it('should deselect all rows when not playing', () => {
+    grid['gridApi'].deselectAll = jest.fn();
+    grid.setPlaybackPosition(5, false);
+    expect(grid['gridApi'].deselectAll).toHaveBeenCalled();
+  });
+
+  it('should select and scroll to row containing playback position when playing', () => {
+    grid.addSegments([
+      { start: 0, end: 10, text: 'Segment 1', score: 0.9 },
+      { start: 10, end: 20, text: 'Segment 2', score: 0.8 },
+      { start: 20, end: 30, text: 'Segment 3', score: 0.7 }
+    ], makeAudioSource('Test Audio', 'test123'));
+
+    grid['gridApi'].getRowNode = jest.fn().mockReturnValue({
+      setSelected: jest.fn(),
+      isSelected: jest.fn().mockReturnValue(false)
+    }) as jest.Mock<any>;
+
+    grid['gridApi'].deselectAll = jest.fn();
+    grid['gridApi'].ensureNodeVisible = jest.fn();
+
+    grid.setPlaybackPosition(15, true);
+
+    expect(grid['gridApi'].getRowNode).toHaveBeenCalledWith('test123-1');
+    const node = grid['gridApi'].getRowNode('test123-1');
+    expect(node?.setSelected).toHaveBeenCalledWith(true);
+    expect(grid['gridApi'].deselectAll).toHaveBeenCalled();
+    expect(grid['gridApi'].ensureNodeVisible).toHaveBeenCalledWith(node);
+  });
+
+  it('should not change selection if position is outside any segment', () => {
+    grid.addSegments([
+      { start: 0, end: 10, text: 'Segment 1', score: 0.9 },
+      { start: 10, end: 20, text: 'Segment 2', score: 0.8 },
+      { start: 20, end: 30, text: 'Segment 3', score: 0.7 }
+    ], makeAudioSource('Test Audio', 'test123'));
+
+    grid['gridApi'].getRowNode = jest.fn().mockReturnValue({
+      setSelected: jest.fn(),
+      isSelected: jest.fn().mockReturnValue(false)
+    }) as jest.Mock<any>;
+
+    grid['gridApi'].deselectAll = jest.fn();
+    grid['gridApi'].ensureNodeVisible = jest.fn();
+
+    grid.setPlaybackPosition(35, true);
+
+    expect(grid['gridApi'].getRowNode).not.toHaveBeenCalled();
+    expect(grid['gridApi'].deselectAll).not.toHaveBeenCalled();
+    expect(grid['gridApi'].ensureNodeVisible).not.toHaveBeenCalled();
+  });
+
   it('should update rows with correct playback regions', () => {
     const playbackRegionsBySourceID = new Map<string, PlaybackRegion[]>();
     playbackRegionsBySourceID.set('test123', [

--- a/source/ts/tests/TranscriptGrid.test.ts
+++ b/source/ts/tests/TranscriptGrid.test.ts
@@ -244,6 +244,30 @@ describe('TranscriptGrid', () => {
     expect(grid['gridApi'].ensureNodeVisible).not.toHaveBeenCalled();
   });
 
+  it('should not select row if already selected', () => {
+    grid.addSegments([
+      { start: 0, end: 10, text: 'Segment 1', score: 0.9 },
+      { start: 10, end: 20, text: 'Segment 2', score: 0.8 },
+      { start: 20, end: 30, text: 'Segment 3', score: 0.7 }
+    ], makeAudioSource('Test Audio', 'test123'));
+
+    grid['gridApi'].getRowNode = jest.fn().mockReturnValue({
+      setSelected: jest.fn(),
+      isSelected: jest.fn().mockReturnValue(true)
+    }) as jest.Mock<any>;
+
+    grid['gridApi'].deselectAll = jest.fn();
+    grid['gridApi'].ensureNodeVisible = jest.fn();
+
+    grid.setPlaybackPosition(15, true);
+
+    expect(grid['gridApi'].getRowNode).toHaveBeenCalledWith('test123-1');
+    const node = grid['gridApi'].getRowNode('test123-1');
+    expect(node?.setSelected).not.toHaveBeenCalled();
+    expect(grid['gridApi'].deselectAll).not.toHaveBeenCalled();
+    expect(grid['gridApi'].ensureNodeVisible).not.toHaveBeenCalled();
+  });
+
   it('should update rows with correct playback regions', () => {
     const playbackRegionsBySourceID = new Map<string, PlaybackRegion[]>();
     playbackRegionsBySourceID.set('test123', [


### PR DESCRIPTION
During playback in Reaper, if the user clicks the pause button, the transcript can't be scrolled because it will keep scrolling back to the current segment. This is because the paused state is still considered "playing", so the auto-scroll behavior continues. This change fixes that behavior by not reselecting (and re-scrolling) an already selected row.

Incidentally, there is no way to get "paused" state from VST apparently. In a previous iteration I tried using the REAPER API to get that state. However, this fix does not depend on needing to know the paused state, so it should work (citation needed) with other DAWs.