### PR TITLE
Initialize whisper_context_params properly

### DIFF
--- a/source/asr/ASREngine.h
+++ b/source/asr/ASREngine.h
@@ -121,8 +121,7 @@ public:
             return false;
         }
 
-        whisper_context_params params;
-        params.use_gpu = true;
+        whisper_context_params params = whisper_context_default_params();
 
         ctx = whisper_init_from_file_with_params (modelPath.c_str(), params);
         if (ctx == nullptr)


### PR DESCRIPTION
Initialize whisper_context_params properly - Fixes #45 

Initializing a struct without providing values for its members results in undefined behavior. whisper.cpp provides an initialization function, `whisper_context_default_params()`, which we were not calling. It defaults to `use_gpu = true`, so we can remove that explicit setting.