### PR TITLE
Add CSV and SRT export

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -55,15 +55,27 @@
         <div class="d-flex justify-content-between align-items-center mb-2">
           <h4 class="mb-0">Transcript</h4>
 
-          <div id="create-menu" class="dropdown" style="display: none">
-            <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-              Create
-            </button>
-            <ul class="dropdown-menu">
-              <li><a id="create-markers" class="dropdown-item" href="javascript:">Markers</a></li>
-              <li><a id="create-regions" class="dropdown-item" href="javascript:">Regions</a></li>
-              <li><a id="create-notes" class="dropdown-item" href="javascript:">Notes</a></li>
-            </ul>
+          <div class="d-flex gap-2">
+            <div id="create-menu" class="dropdown" style="display: none">
+              <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Create
+              </button>
+              <ul class="dropdown-menu">
+                <li><a id="create-markers" class="dropdown-item" href="javascript:">Markers</a></li>
+                <li><a id="create-regions" class="dropdown-item" href="javascript:">Regions</a></li>
+                <li><a id="create-notes" class="dropdown-item" href="javascript:">Notes</a></li>
+              </ul>
+            </div>
+
+            <div id="export-menu" class="dropdown">
+              <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Export
+              </button>
+              <ul class="dropdown-menu">
+                <li><a id="export-csv" class="dropdown-item" href="javascript:">CSV</a></li>
+                <li><a id="export-srt" class="dropdown-item" href="javascript:">SRT</a></li>
+              </ul>
+            </div>
           </div>
         </div>
 

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -73,8 +73,8 @@ export default class App {
   }
 
   initExportButton() {
-    document.getElementById('export-csv').onclick = () => { this.transcriptGrid.exportCSV(); };
-    document.getElementById('export-srt').onclick = () => { this.transcriptGrid.exportSRT(); };
+    document.getElementById('export-csv').onclick = () => { this.transcriptGrid.exportCSV(this.saveAs.bind(this)); }
+    document.getElementById('export-srt').onclick = () => { this.transcriptGrid.exportSRT(this.saveAs.bind(this)); };
   }
 
   startPolling() {
@@ -397,6 +397,19 @@ export default class App {
       return this.native.setPlaybackPosition(seconds).then(() => {
         return this.native.play();
       });
+    });
+  }
+
+  saveAs(content: string, _mimeType: string, filename: string) {
+    const title = "Save As";
+    const extension = filename.split('.').pop();
+    const patterns = "*." + extension;
+    return this.native.saveFile(title, filename, patterns, content).then((result) => {
+      if (result.error) {
+        this.showAlert('danger', '<b>Error:</b> ' + htmlEscape(result.error));
+      } else if (result.filePath) {
+        this.showAlert('success', '<b>Success:</b> File saved to ' + htmlEscape(result.filePath));
+      }
     });
   }
 }

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -35,6 +35,7 @@ export default class App {
     this.initState();
     this.initProcessButton();
     this.initCreateButton();
+    this.initExportButton();
     this.startPolling();
   }
 
@@ -69,6 +70,11 @@ export default class App {
     document.getElementById('create-markers').onclick = () => { this.handleCreateMarkers('markers'); };
     document.getElementById('create-regions').onclick = () => { this.handleCreateMarkers('regions'); };
     document.getElementById('create-notes').onclick = () => { this.handleCreateMarkers('notes'); };
+  }
+
+  initExportButton() {
+    document.getElementById('export-csv').onclick = () => { this.transcriptGrid.exportCSV(); };
+    document.getElementById('export-srt').onclick = () => { this.transcriptGrid.exportSRT(); };
   }
 
   startPolling() {

--- a/source/ts/src/Native.ts
+++ b/source/ts/src/Native.ts
@@ -12,6 +12,7 @@ export default class Native {
   getWhisperLanguages = Juce.getNativeFunction("getWhisperLanguages");
   play = Juce.getNativeFunction("play");
   stop = Juce.getNativeFunction("stop");
+  saveFile = Juce.getNativeFunction("saveFile");
   setPlaybackPosition = Juce.getNativeFunction("setPlaybackPosition");
   setWebState = Juce.getNativeFunction("setWebState");
   transcribeAudioSource = Juce.getNativeFunction("transcribeAudioSource");

--- a/source/ts/src/TranscriptGrid.ts
+++ b/source/ts/src/TranscriptGrid.ts
@@ -83,18 +83,18 @@ export default class TranscriptGrid {
     this.rowData.length = 0;
   }
 
-  exportCSV() {
+  exportCSV(onDownloadFile = downloadFile) {
     const params: CsvExportParams = {
       exportedRows: 'all',
       processCellCallback: this.processCellForCSV.bind(this),
     };
     const csvContent = this.gridApi.getDataAsCsv(params);
-    downloadFile(csvContent, 'text/csv;charset=utf-8', 'transcript.csv');
+    onDownloadFile(csvContent, 'text/csv;charset=utf-8', 'transcript.csv');
   }
 
-  exportSRT() {
+  exportSRT(onDownloadFile = downloadFile) {
     const srtContent = this.rowData.map(this.processRowForSRT.bind(this)).join('\n');
-    downloadFile(srtContent, 'application/x-subrip', 'transcript.srt');
+    onDownloadFile(srtContent, 'application/x-subrip', 'transcript.srt');
   }
 
   processCellForCSV(params: ProcessCellForExportParams): any {

--- a/source/ts/src/Utils.ts
+++ b/source/ts/src/Utils.ts
@@ -8,6 +8,26 @@ export function delay(ms: number): Promise<void> {
 }
 
 /**
+ * Triggers the browser's file download behavior for a file with the specified
+ * content, MIME type, and filename.
+ * @param content The content of the file.
+ * @param mimeType The MIME type of the file.
+ * @param filename The name of the file to be downloaded.
+ * @returns {void}
+ */
+export function downloadFile(content: string, mimeType: string, filename: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.setAttribute('href', url);
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+}
+
+/**
  * Escapes HTML special characters in a string.
  * @param str The string to escape.
  * @returns The escaped string.
@@ -36,4 +56,23 @@ export function timestampToString(seconds: number): string {
   } else {
     return `${neg}${minutes}:${String(wholeSeconds).padStart(2, '0')}.${String(milliseconds).padStart(3, '0')}`;
   }
+}
+
+/**
+ * Returns a string of the form HH:MM:SS,mmm from a number of seconds.
+ * This format should be compatible with SRT files.
+ * Milliseconds are always rounded down to three decimal places.
+ * @param seconds The time in seconds.
+ * @returns The formatted string.
+ */
+export function timestampToStringSRT(seconds: number): string {
+  const neg = seconds < 0 ? '-' : '';
+  seconds = Math.abs(seconds);
+
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor(seconds / 60) % 60;
+  const wholeSeconds = Math.floor(seconds) % 60;
+  const milliseconds = Math.floor(seconds * 1000) % 1000;
+
+  return `${neg}${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(wholeSeconds).padStart(2, '0')},${String(milliseconds).padStart(3, '0')}`;
 }

--- a/source/ts/tests/TranscriptGrid.test.ts
+++ b/source/ts/tests/TranscriptGrid.test.ts
@@ -347,4 +347,52 @@ describe('TranscriptGrid', () => {
     options.onCellClicked!(params);
     expect(onPlayAt).not.toHaveBeenCalled();
   });
+
+  it('processes cells for CSV export', () => {
+    // Test timestamp formatting
+    const timeParams = {
+      value: 10,
+      column: { getColId: () => 'playbackStart' },
+    } as any;
+    expect(grid.processCellForCSV(timeParams)).toBe('0:10.000');
+
+    // Test null values
+    timeParams.value = null;
+    expect(grid.processCellForCSV(timeParams)).toBe('');
+
+    // Test score formatting
+    const scoreParams = {
+      value: 0.756,
+      column: { getColId: () => 'score' },
+    } as any;
+    expect(grid.processCellForCSV(scoreParams)).toBe('0.76');
+
+    // Test null score
+    scoreParams.value = null;
+    expect(grid.processCellForCSV(scoreParams)).toBe('');
+
+    // Test other columns
+    const otherParams = {
+      value: 'test',
+      column: { getColId: () => 'text' },
+    } as any;
+    expect(grid.processCellForCSV(otherParams)).toBe('test');
+  });
+
+  it('processes rows for SRT export', () => {
+    const row = {
+      id: 'test123-0',
+      start: 10,
+      end: 20,
+      playbackStart: 10,
+      playbackEnd: 20,
+      text: 'Hello',
+      score: 0.95,
+      source: 'Test Audio',
+      sourceID: 'test123',
+    };
+    const index = 0;
+    const result = grid.processRowForSRT(row, index);
+    expect(result).toBe('1\n00:00:10,000 --> 00:00:20,000\nHello\n');
+  });
 });

--- a/source/ts/tests/TranscriptGrid.test.ts
+++ b/source/ts/tests/TranscriptGrid.test.ts
@@ -348,6 +348,80 @@ describe('TranscriptGrid', () => {
     expect(onPlayAt).not.toHaveBeenCalled();
   });
 
+  it('exports CSV', () => {
+    const row1 = {
+      id: 'test123-0',
+      start: 10,
+      end: 20,
+      text: 'Hello',
+      score: 0.95,
+      source: 'Test Audio',
+      sourceID: 'test123'
+    };
+    const row2 = {
+      id: 'test123-1',
+      start: 30,
+      end: 40,
+      text: 'World',
+      score: 0.85,
+      source: 'Test Audio',
+      sourceID: 'test123'
+    };
+    grid.addRows([row1, row2]);
+
+    grid['gridApi'].getDataAsCsv = jest.fn((params) => {
+      return 'generated CSV content';
+    });
+
+    let content = '', mimeType = '', filename = '';
+    grid.exportCSV((c, m, f) => {
+      content = c;
+      mimeType = m;
+      filename = f;
+    });
+
+    expect(content).toBe('generated CSV content');
+    expect(mimeType).toBe('text/csv;charset=utf-8');
+    expect(filename).toBe('transcript.csv');
+  });
+
+  it('exports SRT', () => {
+    const row1 = {
+      id: 'test123-0',
+      start: 10,
+      end: 20,
+      playbackStart: 10,
+      playbackEnd: 20,
+      text: 'Hello',
+      score: 0.95,
+      source: 'Test Audio',
+      sourceID: 'test123'
+    };
+    const row2 = {
+      id: 'test123-1',
+      start: 30,
+      end: 40,
+      playbackStart: 30,
+      playbackEnd: 40,
+      text: 'World',
+      score: 0.85,
+      source: 'Test Audio',
+      sourceID: 'test123'
+    };
+    grid.addRows([row1, row2]);
+
+    let content = '', mimeType = '', filename = '';
+    grid.exportSRT((c, m, f) => {
+      content = c;
+      mimeType = m;
+      filename = f;
+    });
+
+    expect(content).toBe('1\n00:00:10,000 --> 00:00:20,000\nHello\n\n2\n00:00:30,000 --> 00:00:40,000\nWorld\n');
+    expect(mimeType).toBe('application/x-subrip');
+    expect(filename).toBe('transcript.srt');
+  });
+
   it('processes cells for CSV export', () => {
     // Test timestamp formatting
     const timeParams = {

--- a/source/ts/tests/Utils.test.ts
+++ b/source/ts/tests/Utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { htmlEscape, timestampToString } from '../src/Utils';
+import { htmlEscape, timestampToString, timestampToStringSRT } from '../src/Utils';
 
 describe('Utils', () => {
   describe('htmlEscape', () => {
@@ -50,6 +50,39 @@ describe('Utils', () => {
     it('should handle negative values', () => {
       expect(timestampToString(-65.123)).toBe('-1:05.123');
       expect(timestampToString(-3661.789)).toBe('-1:01:01.789');
+    });
+  });
+
+  describe('timestampToStringSRT', () => {
+    it('should format seconds into M:SS.mmm', () => {
+      expect(timestampToStringSRT(65.123)).toBe('00:01:05,123');
+    });
+
+    it('should handle zero seconds', () => {
+      expect(timestampToStringSRT(0)).toBe('00:00:00,000');
+    });
+
+    it('should handle seconds less than a minute', () => {
+      expect(timestampToStringSRT(45.5)).toBe('00:00:45,500');
+    });
+
+    it('should floor milliseconds', () => {
+      expect(timestampToStringSRT(10.1234)).toBe('00:00:10,123');
+      expect(timestampToStringSRT(10.1239)).toBe('00:00:10,123');
+    });
+
+    it('should pad seconds and milliseconds with leading zeros', () => {
+      expect(timestampToStringSRT(1.1)).toBe('00:00:01,100');
+      expect(timestampToStringSRT(10.01)).toBe('00:00:10,010');
+    });
+
+    it('should handle large values', () => {
+      expect(timestampToStringSRT(3661.789)).toBe('01:01:01,789');
+    });
+
+    it('should handle negative values', () => {
+      expect(timestampToStringSRT(-65.123)).toBe('-00:01:05,123');
+      expect(timestampToStringSRT(-3661.789)).toBe('-01:01:01,789');
     });
   });
 });


### PR DESCRIPTION
This adds a CSV export feature based on ag-grid's built-in CSV export, and an SRT export written by hand. It includes a general-purpose utility function for triggering browser downloads from string content.