### PR TITLE
Disable non-release CUDA builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,8 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      SHOULD_SKIP: false # default value, will be overridden in first step if needed
     strategy:
       fail-fast: false # show all errors for each platform (vs. cancel jobs on error)
       matrix:
@@ -58,37 +60,46 @@ jobs:
             extra-flags: -DGGML_CUDA=1 -DGGML_STATIC=1 -DCMAKE_CUDA_ARCHITECTURES=all
 
     steps:
+      - name: Check if build should be skipped
+        run: |
+          if [[ "${{ matrix.cuda }}" == "true" && "${{ github.ref }}" != *"tags/v"* ]]; then
+            echo "SHOULD_SKIP=true" >> $GITHUB_ENV
+            echo "::notice::CUDA build '${{ matrix.name }}' will be skipped - only runs on releases (tags starting with 'v')"
+          fi
+
       - name: Maximize build space
-        if: runner.os == 'Linux'
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Linux'
         uses: easimon/maximize-build-space@v10
         with:
           root-reserve-mb: 20000
 
-      # Setup MSVC toolchain and developer command prompt (Windows)
-      - uses: ilammy/msvc-dev-cmd@v1
+      # Set up MSVC toolchain and developer command prompt (Windows)
+      - name: Set up MSVC
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
 
       # Use clang on Linux so we don't introduce a 3rd compiler (Windows and macOS use MSVC and Clang)
       - name: Set up Clang
-        if: runner.os == 'Linux'
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Linux'
         uses: egor-tensin/setup-clang@v1
 
       # Set up cuda-toolkit for CUDA targets
       - name: Set up CUDA
-        if: ${{ matrix.cuda == true }}
+        if: env.SHOULD_SKIP != 'true' && matrix.cuda
         uses: Jimver/cuda-toolkit@v0.2.22
         with:
           cuda: ${{ matrix.cuda-version }}
 
       # This also starts up our "fake" display (Xvfb), needed for pluginval
       - name: Install JUCE Linux Deps
-        if: runner.os == 'Linux'
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Linux'
         # Thanks to McMartin & co https://forum.juce.com/t/list-of-juce-dependencies-under-linux/15121/44
         run: |
           sudo apt-get update && sudo apt install libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev xvfb ninja-build libcurl4-openssl-dev
           sudo /usr/bin/Xvfb $DISPLAY &
 
       - name: Cache IPP (Windows)
-        if: runner.os == 'Windows'
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows'
         id: cache-ipp
         uses: actions/cache@v4
         with:
@@ -96,40 +107,42 @@ jobs:
           path: C:\Program Files (x86)\Intel
 
       - name: Install IPP (Windows)
-        if: (runner.os == 'Windows') && (steps.cache-ipp.outputs.cache-hit != 'true')
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows' && steps.cache-ipp.outputs.cache-hit != 'true'
         run: |
           curl --output oneapi.exe https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2e89fab4-e1c7-4f14-a1ef-6cddba8c5fa7/intel-ipp-2022.0.0.796_offline.exe
           ./oneapi.exe -s -x -f oneapi
           ./oneapi/bootstrapper.exe -s -c --action install --components=intel.oneapi.win.ipp.devel --eula=accept -p=NEED_VS2022_INTEGRATION=1 --log-dir=.
 
       - name: Save IPP cache (even on CI fail)
-        if: runner.os == 'Windows' && (steps.cache-ipp.outputs.cache-hit != 'true')
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows' && steps.cache-ipp.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: C:\Program Files (x86)\Intel
           key: ipp-v6
 
       - name: Install Ninja (Windows)
-        if: runner.os == 'Windows'
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows'
         run: choco install ninja
 
       - name: Install macOS Deps
-        if: ${{ matrix.name == 'macOS' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'macOS'
         run: brew install ninja osxutils
 
       # This block can be removed once 15.1 is default (JUCE requires it when building on macOS 14)
       - name: Use latest Xcode on system (macOS)
-        if: ${{ matrix.name == 'macOS' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
 
       - name: Checkout code
+        if: env.SHOULD_SKIP != 'true'
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Setup Node.js
+        if: env.SHOULD_SKIP != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -137,24 +150,28 @@ jobs:
           cache-dependency-path: 'source/ts/package-lock.json'
 
       - name: Install TypeScript dependencies
+        if: env.SHOULD_SKIP != 'true'
         working-directory: source/ts
         run: npm ci
 
       - name: Run TypeScript tests
+        if: env.SHOULD_SKIP != 'true'
         working-directory: source/ts
         run: npm run test
 
       - name: Build TypeScript assets
+        if: env.SHOULD_SKIP != 'true'
         working-directory: source/ts
         run: npm run build
 
       - name: Cache the build
+        if: env.SHOULD_SKIP != 'true'
         uses: mozilla-actions/sccache-action@v0.0.9
 
       # - name: Import Certificates (macOS)
+      #   if: env.SHOULD_SKIP != 'true' && runner.os == 'macOS'
       #   uses: sudara/basic-macos-keychain-action@v1
       #   id: keychain
-      #   if: ${{ matrix.name == 'macOS'}}
       #   with:
       #     dev-id-app-cert: ${{ secrets.DEV_ID_APP_CERT }}
       #     dev-id-app-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
@@ -162,21 +179,26 @@ jobs:
       #     dev-id-installer-password: ${{ secrets.DEV_ID_INSTALLER_PASSWORD }}
 
       - name: Configure
+        if: env.SHOULD_SKIP != 'true'
         run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache ${{ matrix.extra-flags }} .
 
       - name: Build
+        if: env.SHOULD_SKIP != 'true'
         run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }} --parallel 4
 
       - name: Test & Benchmarks
+        if: env.SHOULD_SKIP != 'true'
         working-directory: ${{ env.BUILD_DIR }}
         run: ctest --verbose --output-on-failure
 
       - name: Read in .env from CMake # see GitHubENV.cmake
+        if: env.SHOULD_SKIP != 'true'
         run: |
           cat .env # show us the config
           cat .env >> $GITHUB_ENV # pull in our PRODUCT_NAME, etc
 
       - name: Set additional env vars for next steps
+        if: env.SHOULD_SKIP != 'true'
         run: |
           ARTIFACTS_PATH=${{ env.BUILD_DIR }}/${{ env.PROJECT_NAME }}_artefacts/${{ env.BUILD_TYPE }}
           echo "ARTIFACTS_PATH=$ARTIFACTS_PATH" >> $GITHUB_ENV
@@ -185,7 +207,7 @@ jobs:
           echo "ARTIFACT_NAME=${{ env.PRODUCT_NAME }}-${{ env.VERSION }}-${{ matrix.name }}" >> $GITHUB_ENV
 
       - name: Copy CUBLAS DLL for Windows CUDA build
-        if: ${{ matrix.name == 'WindowsCUDA' }}
+        if: env.SHOULD_SKIP != 'true' && matrix.name == 'WindowsCUDA'
         run: |
           CUDA_BIN_DIR="$(dirname "$(which nvcc)")/"
           CUBLAS_DLL="${CUDA_BIN_DIR}/cublas64_12.dll"
@@ -194,14 +216,14 @@ jobs:
           echo "CUDA DLL copied successfully"
 
       - name: Pluginval
-        if: ${{ matrix.name != 'WindowsCUDA' && matrix.name != 'LinuxCUDA' }}
+        if: env.SHOULD_SKIP != 'true' && !matrix.cuda
         run: |
           curl -LO "https://github.com/Tracktion/pluginval/releases/download/v1.0.3/pluginval_${{ matrix.name }}.zip"
           7z x pluginval_${{ matrix.name }}.zip
           ${{ matrix.pluginval-binary }} --strictness-level 10 --verbose --validate "${{ env.VST3_PATH }}"
 
       # - name: Codesign (macOS)
-      #   if: ${{ matrix.name == 'macOS' }}
+      #   if: env.SHOULD_SKIP != 'true' && runner.os == 'macOS'
       #   run: |
       #     # Each plugin must be code signed
       #     codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.VST3_PATH }}" --deep --strict --options=runtime --timestamp
@@ -210,7 +232,7 @@ jobs:
       #     codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v "${{ env.STANDALONE_PATH }}" --deep --strict --options=runtime --timestamp
 
       # - name: Add Custom Icons (macOS)
-      #   if: ${{ matrix.name == 'macOS' }}
+      #   if: env.SHOULD_SKIP != 'true' && runner.os == 'macOS'
       #   run: |
       #     # add the icns as its own icon resource (meta!)
       #     sips -i packaging/pamplejuce.icns
@@ -229,7 +251,7 @@ jobs:
       #     SetFile -a C "${{ env.CLAP_PATH }}"
 
       - name: pkgbuild, Productbuild and Notarize
-        if: ${{ matrix.name == 'macOS' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'macOS'
         timeout-minutes: 5
         run: |
           pkgbuild --identifier "${{ env.BUNDLE_ID }}.vst3.pkg" --version $VERSION --component "${{ env.VST3_PATH }}" --install-location "/Library/Audio/Plug-Ins/VST3" "packaging/${{ env.ARTIFACT_NAME }}.pkg"
@@ -242,18 +264,18 @@ jobs:
           # xcrun stapler staple "${{ env.ARTIFACT_NAME }}.pkg"
 
       - name: Zip
-        if: ${{ matrix.name == 'Linux' || matrix.name == 'LinuxCUDA' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Linux'
         working-directory: ${{ env.ARTIFACTS_PATH }}
         run: 7z a -tzip "${{ env.ARTIFACT_NAME }}.zip" "-xr!lib${{ env.PRODUCT_NAME }}_SharedCode.a" .
 
       - name: Generate Installer
-        if: ${{ matrix.name == 'Windows' || matrix.name == 'WindowsCUDA' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows'
         run: |
           iscc "packaging\installer.iss"
           mv "packaging/Output/${{ env.ARTIFACT_NAME }}.exe" "${{ env.ARTIFACTS_PATH }}/"
 
       # - name: Codesign with Azure Trusted Signing
-      #   if: ${{ matrix.name == 'Windows' || matrix.name == 'WindowsCUDA' }}
+      #   if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows'
       #   uses: azure/trusted-signing-action@v0.5.0
       #   with:
       #     # The Azure Active Directory tenant (directory) ID.
@@ -279,21 +301,21 @@ jobs:
       #     files-folder-filter: exe
 
       - name: Upload Exe (Windows)
-        if: ${{ matrix.name == 'Windows' || matrix.name == 'WindowsCUDA' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}.exe
           path: "${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.exe"
 
       - name: Upload Zip (Linux)
-        if: ${{ matrix.name == 'Linux' || matrix.name == 'LinuxCUDA' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'Linux'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}.zip
           path: "${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.zip"
 
       - name: Upload pkg (macOS)
-        if: ${{ matrix.name == 'macOS' }}
+        if: env.SHOULD_SKIP != 'true' && runner.os == 'macOS'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ARTIFACT_NAME }}.pkg


### PR DESCRIPTION
This change disables CUDA builds except for releases. CUDA builds are very slow, and it's wasteful to build for CUDA on every pull request or feature branch update.

I considered a few different ways of doing this and settled on this solution because it was the least invasive. It sets an environment variable, `SHOULD_SKIP`, as the first build step, and then each subsequent step needs to check this variable. This is repetitive, but the other options are considerably more involved:

- Two jobs could be used, "build_and_test", and "build_and_test_cuda". The "needs" field for release would then depend on both of these jobs. In order to avoid duplicating all the steps for each of these jobs, the steps would need to be moved to a different file as a "Reusable Workflow". This would require a lot of testing because there are assumptions around the matrix variables and how they are passed into various build steps.
- We could stop using matrix fields for things like "name", "extra-flags", "cuda-version", etc. The matrix system is designed to do a cross-product, so we could define "os", "cuda", and "isRelease" fields and have it compute all possible combinations, then use "exclude" to filter out undesired results such as "os=macOS, cuda=true" and "cuda=true, isRelease=false". However, this means we have to completely redo the way matrix fields are used throughout the build, since we can't include any extra fields without messing up this cross-product.
- It's also possible to compute the matrix programmatically, by having an initial job that generates a JSON string, and then parsing that JSON string, e.g. `matrix: ${{fromJson(needs.init.outputs.matrix)}}`. Generating a JSON string with all the fields we need is pretty awkward, though.

There have been various feature requests for GitHub Workflows that would make it easier to skip workflows or enable jobs to run conditionally based on the matrix selection, but they seem to all be closed as "won't fix".