### PR TITLE
Reset progress bar when not processing

### DIFF
--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -326,7 +326,15 @@ export default class App {
 
   setProgress(progress: number) {
     const progressElement = document.getElementById('progress');
+    if (!progressElement) {
+      console.warn('Progress element not found in the DOM.');
+      return;
+    }
     const progressBar = progressElement.querySelector('.progress-bar') as HTMLElement;
+    if (!progressBar) {
+      console.warn('Progress bar element not found in the DOM.');
+      return;
+    }
     progressElement.setAttribute('aria-valuenow', progress.toString());
     progressBar.style.width = progress + '%';
   }

--- a/source/ts/src/App.ts
+++ b/source/ts/src/App.ts
@@ -283,16 +283,14 @@ export default class App {
 
   updateTranscriptionStatus() {
     if (!this.processing) {
+      this.setProgress(0);
       return Promise.resolve();
     }
     return this.native.getTranscriptionStatus().then((status) => {
       if (status.status !== '') {
         this.setProcessText(status.status + '...');
       }
-      const progress = document.getElementById('progress');
-      const progressBar = progress.querySelector('.progress-bar') as HTMLElement;
-      progress.setAttribute('aria-valuenow', status.progress.toString());
-      progressBar.style.width = status.progress + '%';
+      this.setProgress(status.progress);
     });
   }
 
@@ -324,6 +322,13 @@ export default class App {
 
   setProcessText(text) {
     document.getElementById('process-text').innerText = text;
+  }
+
+  setProgress(progress: number) {
+    const progressElement = document.getElementById('progress');
+    const progressBar = progressElement.querySelector('.progress-bar') as HTMLElement;
+    progressElement.setAttribute('aria-valuenow', progress.toString());
+    progressBar.style.width = progress + '%';
   }
 
   enableProcessButton() {

--- a/source/ts/tests/App.test.ts
+++ b/source/ts/tests/App.test.ts
@@ -307,6 +307,26 @@ describe('App', () => {
       mockSetProcessText.mockRestore();
     });
 
+    it('resets progress bar when not processing', async () => {
+      const app = new App();
+      const progress = document.getElementById('progress');
+      const progressBar = progress?.querySelector('.progress-bar') as HTMLElement;
+
+      if (!progress || !progressBar) {
+        throw new Error('Progress element or progress bar not found');
+      }
+
+      progress.setAttribute('aria-valuenow', '50');
+      progressBar.style.width = '50%';
+
+      app.processing = false;
+
+      await app.updateTranscriptionStatus();
+
+      expect(progress.getAttribute('aria-valuenow')).toBe('0');
+      expect(progressBar.style.width).toBe('0%');
+    });
+
     it('updates playback regions', async () => {
       const app = new App();
 


### PR DESCRIPTION
Adding cancellation introduced a bug where the progress bar sometimes never resets when processing finishes (it remains stuck at 99% or so). This is because we stop polling for transcription status in that case. This change explicitly resets the progress bar when not processing.