### PR TITLE
Add CUDA 13 support and upgrade dependencies

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,9 +51,15 @@ jobs:
           - name: WindowsCUDA
             os: windows-latest
             cuda: true
-            cuda-version: '12.4.0'
+            cuda-version: '12.5.0'
             release-only: true
             extra-flags: -DGGML_CUDA=1 -DGGML_STATIC=1 -DCMAKE_CUDA_ARCHITECTURES=all
+          - name: WindowsCUDA13
+            os: windows-latest
+            cuda: true
+            cuda-version: '13.1.0'
+            release-only: true
+            extra-flags: -DGGML_CUDA=1 -DGGML_STATIC=1 -DCMAKE_CUDA_ARCHITECTURES="75-real;80-real;86-real;89-real;90-real;100-real;100-virtual"
 
     steps:
       - name: Check if build should be skipped
@@ -76,7 +82,7 @@ jobs:
       # Set up cuda-toolkit for CUDA targets
       - name: Set up CUDA
         if: env.SHOULD_SKIP != 'true' && matrix.cuda
-        uses: Jimver/cuda-toolkit@v0.2.22
+        uses: Jimver/cuda-toolkit@v0.2.30
         with:
           cuda: ${{ matrix.cuda-version }}
 


### PR DESCRIPTION
This change adds a new build target, `WindowsCUDA13`, which builds using CUDA 13 instead of CUDA 12, and attempts to build for all GPUs supported by CUDA 13, including PTX support for future architectures. CUDA 13 is dropping support for older (<7.5) architectures, so the oldest architecture supported in this build is 7.5.

Supported architectures:

- 75-real (Turing): e.g., RTX 20-series, Quadro RTX, Tesla T4.
- 80-real (Ampere): e.g., A100, RTX 3080/3090.
- 86-real (Ampere): e.g., RTX 30-series (consumer), RTX A-series.
- 89-real (Ada Lovelace): e.g., RTX 40-series.
- 90-real (Hopper): e.g., H100.
- 100-real (Blackwell): Next-generation Blackwell GPUs
- 100-virtual: Generates PTX for the compute_100 architecture

I previously attempted `CMAKE_CUDA_ARCHITECTURES=all`, but that resulted in a build so slow that it timed out after 6 hours.