### PR TITLE
Use WindowedSinc, avoid resampling if sample rates match

### DIFF
--- a/source/ara/ReaSpeechLitePlaybackRenderer.h
+++ b/source/ara/ReaSpeechLitePlaybackRenderer.h
@@ -97,15 +97,12 @@ private:
             readerSource = std::make_unique<juce::AudioFormatReaderSource> (
                 new juce::ARAAudioSourceReader (audioSource), true);
         }
-
-        auto resamplingSource = std::make_unique<juce::ResamplingAudioSource> (
-            readerSource.get(), false, audioSource->getChannelCount());
-
-        resamplingSource->setResamplingRatio (audioSource->getSampleRate() / destSampleRate);
-
         resamplers.emplace (audioSource, std::make_unique<ResamplingDriver> (
             std::move (readerSource),
-            std::move (resamplingSource)));
+            audioSource->getChannelCount(),
+            audioSource->getSampleRate() / destSampleRate,
+            maximumSamplesPerBlock,
+            destSampleRate));
     }
 
     juce::BufferingAudioReader* buildBufferedReader(juce::ARAAudioSource* audioSource)
@@ -198,7 +195,7 @@ private:
             * sourceSamplesPerDestSample);
 
         resampler->seek (sourceStartSample);
-        resampler->read (juce::AudioSourceChannelInfo (*tempBuffer));
+        resampler->read (juce::AudioSourceChannelInfo (tempBuffer.get(), 0, destNumSamples));
 
         // Mix local buffer into the output buffer.
         for (int destChannel = 0; destChannel < destNumChannels; ++destChannel)

--- a/source/utils/ResamplingDriver.h
+++ b/source/utils/ResamplingDriver.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstring>
 #include <memory>
+#include <vector>
 
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_audio_formats/juce_audio_formats.h>
@@ -10,28 +12,77 @@ class ResamplingDriver
 public:
     ResamplingDriver(
         std::unique_ptr<juce::AudioFormatReaderSource> sourceIn,
-        std::unique_ptr<juce::ResamplingAudioSource> resamplerIn
+        int sourceNumChannelsIn,
+        double sourceSamplesPerDestSampleIn,
+        int maximumSamplesPerBlockIn,
+        double destSampleRateIn
     ) : source(std::move (sourceIn)),
-        resampler(std::move (resamplerIn))
+        sourceNumChannels (sourceNumChannelsIn),
+        sourceSamplesPerDestSample (sourceSamplesPerDestSampleIn),
+        unityRatio (juce::approximatelyEqual (sourceSamplesPerDestSampleIn, 1.0))
     {
-        prepareToPlay (maximumSamplesPerBlock, destSampleRate);
+        interpolators.resize ((size_t) juce::jmax (1, sourceNumChannels));
+        prepareToPlay (maximumSamplesPerBlockIn, destSampleRateIn);
     }
 
-    void seek(int sourceStartSample)
+    void seek (int sourceStartSample)
     {
-        if (source->getNextReadPosition() != sourceStartSample)
+        if (! hasExpectedSeekPosition)
         {
-            // Clear resampling state if read position is moving significantly
-            if (std::abs (source->getNextReadPosition() - sourceStartSample) > 10)
-                resampler->flushBuffers();
-
             source->setNextReadPosition (sourceStartSample);
+            expectedSeekPosition = sourceStartSample;
+            hasExpectedSeekPosition = true;
+            clearResamplingState();
+            return;
         }
+
+        // Playback renderers repeatedly call seek() with positions derived from rounding.
+        // Keep the interpolator state for tiny drift to avoid zippering artifacts.
+        const auto delta = sourceStartSample - expectedSeekPosition;
+        if (std::abs (delta) <= seekToleranceSamples)
+            return;
+
+        source->setNextReadPosition (sourceStartSample);
+        expectedSeekPosition = sourceStartSample;
+        clearResamplingState();
     }
 
-    void read(const juce::AudioSourceChannelInfo& buffer)
+    void read (const juce::AudioSourceChannelInfo& buffer)
     {
-        resampler->getNextAudioBlock (buffer);
+        if (unityRatio)
+        {
+            source->getNextAudioBlock (buffer);
+            expectedSeekPosition += buffer.numSamples;
+            return;
+        }
+
+        const auto requiredInputSamples = juce::roundToInt (std::ceil (buffer.numSamples * sourceSamplesPerDestSample))
+                                        + interpolationPadding;
+
+        ensureBufferedInput (requiredInputSamples);
+
+        int consumedSamples = 0;
+        const auto channelsToProcess = juce::jmin (sourceNumChannels, buffer.buffer->getNumChannels());
+
+        for (int channel = 0; channel < channelsToProcess; ++channel)
+        {
+            auto* const output = buffer.buffer->getWritePointer (channel, buffer.startSample);
+            const auto* const input = sourceBuffer.getReadPointer (channel);
+
+            const auto used = interpolators[(size_t) channel].process (
+                sourceSamplesPerDestSample,
+                input,
+                output,
+                buffer.numSamples);
+
+            if (channel == 0)
+                consumedSamples = used;
+            else
+                jassert (consumedSamples == used);
+        }
+
+        discardConsumedInput (consumedSamples);
+        expectedSeekPosition += consumedSamples;
     }
 
 private:
@@ -41,13 +92,68 @@ private:
         destSampleRate = destSampleRateIn;
 
         source->prepareToPlay (maximumSamplesPerBlock, destSampleRate);
-        resampler->prepareToPlay (maximumSamplesPerBlock, destSampleRate);
+        sourceBuffer.setSize (juce::jmax (1, sourceNumChannels), maximumSamplesPerBlock * 4);
+        clearResamplingState();
+    }
+
+    void clearResamplingState()
+    {
+        for (auto& interpolator : interpolators)
+            interpolator.reset();
+
+        bufferedInputSamples = 0;
+    }
+
+    void ensureBufferedInput (int minimumSamplesNeeded)
+    {
+        if (sourceBuffer.getNumSamples() < minimumSamplesNeeded)
+            sourceBuffer.setSize (sourceBuffer.getNumChannels(), minimumSamplesNeeded, true, false, true);
+
+        while (bufferedInputSamples < minimumSamplesNeeded)
+        {
+            const auto samplesToRead = minimumSamplesNeeded - bufferedInputSamples;
+            juce::AudioSourceChannelInfo readInfo (&sourceBuffer, bufferedInputSamples, samplesToRead);
+            source->getNextAudioBlock (readInfo);
+            bufferedInputSamples += samplesToRead;
+        }
+    }
+
+    void discardConsumedInput (int consumedSamples)
+    {
+        jassert (consumedSamples >= 0);
+        jassert (consumedSamples <= bufferedInputSamples);
+
+        const auto remainingSamples = bufferedInputSamples - consumedSamples;
+
+        if (remainingSamples > 0)
+        {
+            for (int channel = 0; channel < sourceBuffer.getNumChannels(); ++channel)
+            {
+                auto* const dest = sourceBuffer.getWritePointer (channel);
+                const auto* const src = sourceBuffer.getReadPointer (channel, consumedSamples);
+                std::memmove (dest, src, (size_t) remainingSamples * sizeof (float));
+            }
+        }
+
+        bufferedInputSamples = remainingSamples;
     }
 
     std::unique_ptr<juce::AudioFormatReaderSource> source;
-    std::unique_ptr<juce::ResamplingAudioSource> resampler;
+    std::vector<juce::WindowedSincInterpolator> interpolators;
+
+    const int sourceNumChannels = 1;
+    const double sourceSamplesPerDestSample = 1.0;
+    const bool unityRatio = true;
 
     double destSampleRate = 48000.0;
     int maximumSamplesPerBlock = 128;
+
+    juce::AudioBuffer<float> sourceBuffer;
+    int bufferedInputSamples = 0;
+    int expectedSeekPosition = 0;
+    bool hasExpectedSeekPosition = false;
+
+    static constexpr int interpolationPadding = 16;
+    static constexpr int seekToleranceSamples = 2;
 
 };

--- a/source/utils/ResamplingDriver.h
+++ b/source/utils/ResamplingDriver.h
@@ -91,7 +91,12 @@ private:
         maximumSamplesPerBlock = maximumSamplesPerBlockIn;
         destSampleRate = destSampleRateIn;
 
-        source->prepareToPlay (maximumSamplesPerBlock, destSampleRate);
+        const auto sourceBlockSize = unityRatio
+            ? maximumSamplesPerBlock
+            : juce::roundToInt (std::ceil (maximumSamplesPerBlock * sourceSamplesPerDestSample)) + interpolationPadding;
+        const auto sourceSampleRate = destSampleRateIn * sourceSamplesPerDestSample;
+
+        source->prepareToPlay (sourceBlockSize, sourceSampleRate);
         sourceBuffer.setSize (juce::jmax (1, sourceNumChannels), maximumSamplesPerBlock * 4);
         clearResamplingState();
     }
@@ -155,5 +160,4 @@ private:
 
     static constexpr int interpolationPadding = 16;
     static constexpr int seekToleranceSamples = 2;
-
 };

--- a/source/utils/ResamplingDriver.h
+++ b/source/utils/ResamplingDriver.h
@@ -21,7 +21,8 @@ public:
         sourceSamplesPerDestSample (sourceSamplesPerDestSampleIn),
         unityRatio (juce::approximatelyEqual (sourceSamplesPerDestSampleIn, 1.0))
     {
-        interpolators.resize ((size_t) juce::jmax (1, sourceNumChannels));
+        if (! unityRatio)
+            interpolators.resize ((size_t) juce::jmax (1, sourceNumChannels));
         prepareToPlay (maximumSamplesPerBlockIn, destSampleRateIn);
     }
 
@@ -97,7 +98,8 @@ private:
         const auto sourceSampleRate = destSampleRateIn * sourceSamplesPerDestSample;
 
         source->prepareToPlay (sourceBlockSize, sourceSampleRate);
-        sourceBuffer.setSize (juce::jmax (1, sourceNumChannels), maximumSamplesPerBlock * 4);
+        if (! unityRatio)
+            sourceBuffer.setSize (juce::jmax (1, sourceNumChannels), maximumSamplesPerBlock * 4);
         clearResamplingState();
     }
 


### PR DESCRIPTION
The linear resampling algorithm currently being used by ReaSpeech Lite does not have the greatest sound quality. Ideally, we wouldn't be resampling at all, but due to ARA's design, we have to do playback rendering even if we do not intend to change the audio stream in any way. With this change, resampling is only done if there is actually a sample rate mismatch (e.g. the audio file is 44.1 kHz, but playback is 48 kHz), and it uses the better-quality WindowedSinc algorithm. This is probably the best we can do without importing a third-party SRC library.