### PR TITLE
Disable GPU on Intel Mac

### DIFF
--- a/source/asr/ASREngine.h
+++ b/source/asr/ASREngine.h
@@ -73,6 +73,12 @@ public:
 
         whisper_context_params params = whisper_context_default_params();
 
+#if defined (__APPLE__) && defined (__x86_64__)
+        DBG ("Intel Mac detected, disabling whisper GPU support");
+        params.use_gpu = false;
+        params.flash_attn = false;
+#endif
+
         ctx = whisper_init_from_file_with_params (modelPath.c_str(), params);
         if (ctx == nullptr)
         {


### PR DESCRIPTION
Disable GPU support on Intel Macs. Whisper.cpp does not support GPU acceleration on this architecture, and it crashes when trying to initialize.

Example stack trace:

```
abort()
ggml_abort()
ggml_backend_sched_backend_id_from_cur()
ggml_backend_sched_split_graph()
ggml_backend_sched_alloc_graph()
whisper_sched_graph_init()
whisper_init_state()
whisper_init_from_file_with_params()
ASRThreadPoolJob::runJob()
```